### PR TITLE
Fix critical security and reliability issues across web handlers

### DIFF
--- a/docker/card/db/db_get.go
+++ b/docker/card/db/db_get.go
@@ -82,6 +82,19 @@ func Db_get_total_paid_payments(db_conn *sql.DB, card_id int) int {
 	return value
 }
 
+func Db_get_card_balance(db_conn *sql.DB, card_id int) int {
+	sqlStatement := `SELECT
+		IFNULL((SELECT SUM(amount_sats) FROM card_receipts WHERE paid_flag='Y' AND card_id=$1), 0) -
+		IFNULL((SELECT SUM(amount_sats) + SUM(fee_sats) FROM card_payments WHERE paid_flag='Y' AND card_id=$1), 0)`
+	row := db_conn.QueryRow(sqlStatement, card_id)
+	value := 0
+	err := row.Scan(&value)
+	if err != nil {
+		return 0
+	}
+	return value
+}
+
 type CardLookup struct {
 	CardId int
 	Key1   string

--- a/docker/card/db/db_init.go
+++ b/docker/card/db/db_init.go
@@ -48,6 +48,9 @@ func Db_init(db_conn *sql.DB) {
 		Db_set_setting(db_conn, "invite_secret", "")
 
 		hostDomain := os.Getenv("HOST_DOMAIN")
+		if hostDomain == "" {
+			panic("HOST_DOMAIN environment variable must be set")
+		}
 		Db_set_setting(db_conn, "host_domain", hostDomain)
 		Db_set_setting(db_conn, "gc_url", "")
 		Db_set_setting(db_conn, "log_level", "debug")

--- a/docker/card/db/db_test.go
+++ b/docker/card/db/db_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"database/sql"
+	"os"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -9,6 +10,7 @@ import (
 
 func openTestDB(t *testing.T) *sql.DB {
 	t.Helper()
+	os.Setenv("HOST_DOMAIN", "test.example.com")
 	db, err := sql.Open("sqlite3", ":memory:?_foreign_keys=1")
 	if err != nil {
 		t.Fatal(err)

--- a/docker/card/go.mod
+++ b/docker/card/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
+	golang.org/x/crypto v0.45.0
 )
 
 require (
@@ -65,7 +66,6 @@ require (
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	go.opentelemetry.io/otel v1.39.0 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/net v0.47.0 // indirect

--- a/docker/card/web/admin_register.go
+++ b/docker/card/web/admin_register.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"net/http"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func Register2(db_conn *sql.DB, w http.ResponseWriter, r *http.Request) {
@@ -23,7 +25,12 @@ func Register2(db_conn *sql.DB, w http.ResponseWriter, r *http.Request) {
 		r.ParseForm()
 
 		passwordStr := r.Form.Get("password")
-		passwordHashStr := GetPwHash(db_conn, passwordStr)
+		passwordHashStr, err := HashPassword(passwordStr)
+		if err != nil {
+			log.Error("failed to hash password: ", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
 
 		// TODO: check that password has >128 bit entropy to mitigate brute force attacks
 

--- a/docker/card/web/ajax.go
+++ b/docker/card/web/ajax.go
@@ -74,9 +74,7 @@ func (app *App) CreateHandler_BalanceAjaxPage() http.HandlerFunc {
 		var resObj AjaxBalanceResponse
 
 		// check the card balance
-		total_paid_receipts := db.Db_get_total_paid_receipts(app.db_conn, cardId)
-		total_paid_payments := db.Db_get_total_paid_payments(app.db_conn, cardId)
-		total_card_balance := total_paid_receipts - total_paid_payments
+		total_card_balance := db.Db_get_card_balance(app.db_conn, cardId)
 		resObj.AvailableBalance = total_card_balance
 
 		// get card transactions

--- a/docker/card/web/app.go
+++ b/docker/card/web/app.go
@@ -32,7 +32,7 @@ func (app *App) SetupRoutes() *mux.Router {
 	router.Path("/balance-ajax").Methods("GET").HandlerFunc(app.CreateHandler_BalanceAjaxPage())
 
 	// websocket
-	router.Path("/websocket").HandlerFunc(WebsocketHandler)
+	router.Path("/websocket").HandlerFunc(app.CreateHandler_Websocket())
 
 	// admin dashboard
 	router.PathPrefix("/admin/").HandlerFunc(app.CreateHandler_Admin())

--- a/docker/card/web/bcp_batch_create.go
+++ b/docker/card/web/bcp_batch_create.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"card/db"
-	"card/util"
 	"encoding/json"
 	"net/http"
 	"time"
@@ -32,8 +31,6 @@ func (app *App) CreateHandler_BatchCreateCard() http.HandlerFunc {
 
 		// get secret param
 		secret := r.URL.Query().Get("s")
-
-		log.Info("secret : ", secret)
 
 		// get UID param
 		decoder := json.NewDecoder(r.Body)
@@ -82,7 +79,11 @@ func (app *App) CreateHandler_BatchCreateCard() http.HandlerFunc {
 		bcpBatchResponse.K4 = k4
 
 		resJson, err := json.Marshal(bcpBatchResponse)
-		util.CheckAndPanic(err)
+		if err != nil {
+			log.Error("json marshal error: ", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
 
 		log.Info("resJson ", string(resJson))
 

--- a/docker/card/web/bcp_create.go
+++ b/docker/card/web/bcp_create.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"card/db"
-	"card/util"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -76,7 +75,11 @@ func (app *App) CreateHandler_CreateCard() http.HandlerFunc {
 		resObj.K4 = k4
 
 		resJson, err := json.Marshal(resObj)
-		util.CheckAndPanic(err)
+		if err != nil {
+			log.Error("json marshal error: ", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
 
 		//log.Info("resJson ", string(resJson))
 

--- a/docker/card/web/lnurlw_callback.go
+++ b/docker/card/web/lnurlw_callback.go
@@ -51,9 +51,7 @@ func (app *App) CreateHandler_LnurlwCallback() http.HandlerFunc {
 		}
 
 		// check the card balance
-		total_paid_receipts := db.Db_get_total_paid_receipts(app.db_conn, cardId)
-		total_paid_payments := db.Db_get_total_paid_payments(app.db_conn, cardId)
-		total_card_balance := total_paid_receipts - total_paid_payments
+		total_card_balance := db.Db_get_card_balance(app.db_conn, cardId)
 
 		// calculate the max network fee possible
 		// https://phoenix.acinq.co/faq#what-are-the-fees

--- a/docker/card/web/lnurlw_request.go
+++ b/docker/card/web/lnurlw_request.go
@@ -79,7 +79,11 @@ func (app *App) CreateHandler_LnurlwRequest() http.HandlerFunc {
 
 		// send response
 		resJson, err := json.Marshal(resObj)
-		util.CheckAndPanic(err)
+		if err != nil {
+			log.Error("json marshal error: ", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
 
 		w.Write(resJson)
 	}

--- a/docker/card/web/pos_api_addinvoice.go
+++ b/docker/card/web/pos_api_addinvoice.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"card/phoenix"
-	"card/util"
 	"encoding/json"
 	"net/http"
 	"strconv"
@@ -62,7 +61,11 @@ func (app *App) CreateHandler_PosApi_AddInvoice() http.HandlerFunc {
 			ExternalId:  "ext_id",
 		}
 		invoice, err := phoenix.CreateInvoice(invoiceRequest)
-		util.CheckAndPanic(err)
+		if err != nil {
+			log.Error("phoenix error: ", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
 
 		log.Info("invoice : ", invoice)
 
@@ -78,7 +81,11 @@ func (app *App) CreateHandler_PosApi_AddInvoice() http.HandlerFunc {
 		resp.Hash = invoice.PaymentHash
 
 		respJson, err := json.Marshal(resp)
-		util.CheckAndPanic(err)
+		if err != nil {
+			log.Error("json marshal error: ", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
 
 		log.Info(string(respJson))
 

--- a/docker/card/web/pos_api_getuserinvoices.go
+++ b/docker/card/web/pos_api_getuserinvoices.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"card/phoenix"
-	"card/util"
 	"encoding/json"
 	"net/http"
 
@@ -55,7 +54,11 @@ func (app *App) CreateHandler_PosApi_GetUserInvoices() http.HandlerFunc {
 		}
 
 		respJson, err := json.Marshal(resp)
-		util.CheckAndPanic(err)
+		if err != nil {
+			log.Error("json marshal error: ", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)

--- a/docker/card/web/util.go
+++ b/docker/card/web/util.go
@@ -5,8 +5,12 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"strings"
+
+	"golang.org/x/crypto/bcrypt"
 )
 
+// GetPwHash is the legacy SHA256 password hash (kept for migration)
 func GetPwHash(db_conn *sql.DB, passwordStr string) (passwordHashStr string) {
 	passwordSalt := db.Db_get_setting(db_conn, "admin_password_salt")
 
@@ -17,4 +21,17 @@ func GetPwHash(db_conn *sql.DB, passwordStr string) (passwordHashStr string) {
 	passwordHashStr = hex.EncodeToString(passwordHash)
 
 	return passwordHashStr
+}
+
+func HashPassword(passwordStr string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(passwordStr), bcrypt.DefaultCost)
+	return string(hash), err
+}
+
+func CheckPassword(passwordStr string, hashStr string) bool {
+	return bcrypt.CompareHashAndPassword([]byte(hashStr), []byte(passwordStr)) == nil
+}
+
+func isBcryptHash(hash string) bool {
+	return strings.HasPrefix(hash, "$2a$") || strings.HasPrefix(hash, "$2b$")
 }

--- a/docker/card/web/wallet_api_auth.go
+++ b/docker/card/web/wallet_api_auth.go
@@ -64,7 +64,11 @@ func (app *App) CreateHandler_Auth() http.HandlerFunc {
 			resObj.AccessToken = AccessToken
 
 			resJson, err := json.Marshal(resObj)
-			util.CheckAndPanic(err)
+			if err != nil {
+				log.Error("json marshal error: ", err)
+				http.Error(w, "internal error", http.StatusInternalServerError)
+				return
+			}
 
 			w.Write(resJson) // TODO: not tested yet
 		}
@@ -82,7 +86,7 @@ func (app *App) CreateHandler_Auth() http.HandlerFunc {
 				return
 			}
 
-			log.Info("AuthRequest ", reqObj)
+			log.Info("AuthRequest received for login")
 
 			// create new refresh_token & access_token
 			AccessToken := util.Random_hex()
@@ -101,10 +105,14 @@ func (app *App) CreateHandler_Auth() http.HandlerFunc {
 			resObj.RefreshToken = RefreshToken
 			resObj.AccessToken = AccessToken
 
-			log.Info("AuthResponse ", resObj)
+			log.Info("AuthResponse sent")
 
 			resJson, err := json.Marshal(resObj)
-			util.CheckAndPanic(err)
+			if err != nil {
+				log.Error("json marshal error: ", err)
+				http.Error(w, "internal error", http.StatusInternalServerError)
+				return
+			}
 
 			w.Write(resJson)
 

--- a/docker/card/web/wallet_api_create.go
+++ b/docker/card/web/wallet_api_create.go
@@ -43,9 +43,6 @@ func (app *App) CreateHandler_Create() http.HandlerFunc {
 		db_invite_secret := db.Db_get_setting(app.db_conn, "invite_secret")
 		req_invite_secret := t.InviteSecret
 
-		log.Info("db_invite_secret " + db_invite_secret)
-		log.Info("req_invite_secret " + req_invite_secret)
-
 		if req_invite_secret != db_invite_secret {
 			sendError(w, "Bad auth", 1, "incorrect invite_secret")
 			return
@@ -70,7 +67,11 @@ func (app *App) CreateHandler_Create() http.HandlerFunc {
 		resObj.Password = password
 
 		resJson, err := json.Marshal(resObj)
-		util.CheckAndPanic(err)
+		if err != nil {
+			log.Error("json marshal error: ", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
 
 		w.Write(resJson)
 	}

--- a/docker/card/web/wallet_api_getcardkeys.go
+++ b/docker/card/web/wallet_api_getcardkeys.go
@@ -6,7 +6,6 @@ import (
 
 	"encoding/json"
 	"net/http"
-	"strings"
 
 	_ "github.com/mattn/go-sqlite3"
 	log "github.com/sirupsen/logrus"
@@ -32,9 +31,10 @@ func (app *App) CreateHandler_WalletApi_GetCardKeys() http.HandlerFunc {
 
 		// get access_token
 
-		authToken := r.Header.Get("Authorization")
-		splitToken := strings.Split(authToken, "Bearer ")
-		accessToken := splitToken[1]
+		accessToken, ok := getBearerToken(w, r)
+		if !ok {
+			return
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -73,7 +73,11 @@ func (app *App) CreateHandler_WalletApi_GetCardKeys() http.HandlerFunc {
 		resObj.UidPrivacy = "false"
 
 		resJson, err := json.Marshal(resObj)
-		util.CheckAndPanic(err)
+		if err != nil {
+			log.Error("json marshal error: ", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
 
 		log.Info("resJson ", string(resJson))
 

--- a/docker/card/web/wallet_api_updatecardwithpin.go
+++ b/docker/card/web/wallet_api_updatecardwithpin.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"card/db"
-	"card/util"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -37,9 +36,10 @@ func (app *App) CreateHandler_WalletApi_UpdateCardWithPin() http.HandlerFunc {
 
 		// get access_token
 
-		authToken := r.Header.Get("Authorization")
-		splitToken := strings.Split(authToken, "Bearer ")
-		accessToken := splitToken[1]
+		accessToken, ok := getBearerToken(w, r)
+		if !ok {
+			return
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -116,7 +116,11 @@ func (app *App) CreateHandler_WalletApi_UpdateCardWithPin() http.HandlerFunc {
 		resObj.Status = "OK"
 
 		resJson, err := json.Marshal(resObj)
-		util.CheckAndPanic(err)
+		if err != nil {
+			log.Error("json marshal error: ", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
 
 		w.Write(resJson)
 	}

--- a/docker/card/web/wallet_api_wipecard.go
+++ b/docker/card/web/wallet_api_wipecard.go
@@ -2,11 +2,9 @@ package web
 
 import (
 	"card/db"
-	"card/util"
 
 	"encoding/json"
 	"net/http"
-	"strings"
 
 	_ "github.com/mattn/go-sqlite3"
 	log "github.com/sirupsen/logrus"
@@ -37,9 +35,10 @@ func (app *App) CreateHandler_WalletApi_WipeCard() http.HandlerFunc {
 
 		// get access_token
 
-		authToken := r.Header.Get("Authorization")
-		splitToken := strings.Split(authToken, "Bearer ")
-		accessToken := splitToken[1]
+		accessToken, ok := getBearerToken(w, r)
+		if !ok {
+			return
+		}
 
 		// get card_id from access_token
 
@@ -68,7 +67,11 @@ func (app *App) CreateHandler_WalletApi_WipeCard() http.HandlerFunc {
 		resObj.Uid = "12345678"
 
 		resJson, err := json.Marshal(resObj)
-		util.CheckAndPanic(err)
+		if err != nil {
+			log.Error("json marshal error: ", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
 
 		log.Info("resJson ", string(resJson))
 

--- a/docker/card/web/web_test.go
+++ b/docker/card/web/web_test.go
@@ -1,0 +1,288 @@
+package web
+
+import (
+	"card/db"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db_conn, err := sql.Open("sqlite3", ":memory:?_foreign_keys=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db_conn.Close() })
+	os.Setenv("HOST_DOMAIN", "test.example.com")
+	db.Db_init(db_conn)
+	return db_conn
+}
+
+func openTestApp(t *testing.T) *App {
+	t.Helper()
+	db_conn := openTestDB(t)
+	return NewApp(db_conn)
+}
+
+// Test getBearerToken with valid Bearer token
+func TestGetBearerToken_Valid(t *testing.T) {
+	r := httptest.NewRequest("GET", "/balance", nil)
+	r.Header.Set("Authorization", "Bearer mytoken123")
+	w := httptest.NewRecorder()
+
+	token, ok := getBearerToken(w, r)
+	if !ok {
+		t.Fatal("expected ok=true for valid bearer token")
+	}
+	if token != "mytoken123" {
+		t.Fatalf("expected token 'mytoken123', got '%s'", token)
+	}
+}
+
+// Test getBearerToken with missing Authorization header
+func TestGetBearerToken_Missing(t *testing.T) {
+	r := httptest.NewRequest("GET", "/balance", nil)
+	w := httptest.NewRecorder()
+
+	token, ok := getBearerToken(w, r)
+	if ok {
+		t.Fatal("expected ok=false for missing auth header")
+	}
+	if token != "" {
+		t.Fatalf("expected empty token, got '%s'", token)
+	}
+
+	// Should have written an error response
+	var errResp ErrorResponse
+	err := json.Unmarshal(w.Body.Bytes(), &errResp)
+	if err != nil {
+		t.Fatal("expected JSON error response")
+	}
+	if errResp.Code != 1 {
+		t.Fatalf("expected error code 1, got %d", errResp.Code)
+	}
+}
+
+// Test getBearerToken with malformed (Basic) auth
+func TestGetBearerToken_Malformed(t *testing.T) {
+	r := httptest.NewRequest("GET", "/balance", nil)
+	r.Header.Set("Authorization", "Basic abc123")
+	w := httptest.NewRecorder()
+
+	_, ok := getBearerToken(w, r)
+	if ok {
+		t.Fatal("expected ok=false for Basic auth header")
+	}
+}
+
+// Test balance handler with missing auth header returns error (not panic)
+func TestBalance_MissingAuth(t *testing.T) {
+	app := openTestApp(t)
+	handler := app.CreateHandler_Balance()
+
+	r := httptest.NewRequest("GET", "/balance", nil)
+	w := httptest.NewRecorder()
+
+	// This should NOT panic
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var errResp ErrorResponse
+	err := json.Unmarshal(w.Body.Bytes(), &errResp)
+	if err != nil {
+		t.Fatal("expected JSON error response, got: ", w.Body.String())
+	}
+	if errResp.Error != "Bad auth" {
+		t.Fatalf("expected 'Bad auth' error, got '%s'", errResp.Error)
+	}
+}
+
+// Test balance handler with invalid token
+func TestBalance_InvalidToken(t *testing.T) {
+	app := openTestApp(t)
+	handler := app.CreateHandler_Balance()
+
+	r := httptest.NewRequest("GET", "/balance", nil)
+	r.Header.Set("Authorization", "Bearer invalidtoken")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	var errResp ErrorResponse
+	err := json.Unmarshal(w.Body.Bytes(), &errResp)
+	if err != nil {
+		t.Fatal("expected JSON error response")
+	}
+	if errResp.Code != 1 {
+		t.Fatalf("expected error code 1, got %d", errResp.Code)
+	}
+}
+
+// Test balance handler with valid token returns balance
+func TestBalance_ValidToken(t *testing.T) {
+	app := openTestApp(t)
+
+	// The test data created by db_init includes a test card
+	// We need to set an access token for it
+	// Card 1 should exist from test data - set its access token
+	db.Db_set_setting(app.db_conn, "bolt_card_hub_api", "enabled")
+
+	// Insert a card and set its tokens
+	db.Db_insert_card(app.db_conn, "k0", "k1", "k2", "k3", "k4", "testlogin", "testpass")
+
+	// Set tokens for the card
+	err := db.Db_set_tokens(app.db_conn, "testlogin", "testpass", "testaccesstoken", "testrefreshtoken")
+	if err != nil {
+		t.Fatal("failed to set tokens: ", err)
+	}
+
+	handler := app.CreateHandler_Balance()
+
+	r := httptest.NewRequest("GET", "/balance", nil)
+	r.Header.Set("Authorization", "Bearer testaccesstoken")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	var balResp BalanceResponse
+	err = json.Unmarshal(w.Body.Bytes(), &balResp)
+	if err != nil {
+		t.Fatal("expected JSON balance response, got: ", w.Body.String())
+	}
+	// New card with no transactions should have 0 balance
+	if balResp.BTC.AvailableBalance != 0 {
+		t.Fatalf("expected balance 0, got %d", balResp.BTC.AvailableBalance)
+	}
+}
+
+// Test auth handler with login and password
+func TestAuth_LoginPassword(t *testing.T) {
+	app := openTestApp(t)
+
+	// Insert a card
+	db.Db_insert_card(app.db_conn, "k0", "k1", "k2", "k3", "k4", "authlogin", "authpass")
+
+	handler := app.CreateHandler_Auth()
+
+	body := `{"login":"authlogin","password":"authpass"}`
+	r := httptest.NewRequest("POST", "/auth?type=auth", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	var authResp AuthResponse
+	err := json.Unmarshal(w.Body.Bytes(), &authResp)
+	if err != nil {
+		t.Fatal("expected JSON auth response, got: ", w.Body.String())
+	}
+	if authResp.AccessToken == "" {
+		t.Fatal("expected non-empty access token")
+	}
+	if authResp.RefreshToken == "" {
+		t.Fatal("expected non-empty refresh token")
+	}
+}
+
+// Test auth handler with invalid credentials
+func TestAuth_InvalidCredentials(t *testing.T) {
+	app := openTestApp(t)
+	handler := app.CreateHandler_Auth()
+
+	body := `{"login":"badlogin","password":"badpass"}`
+	r := httptest.NewRequest("POST", "/auth?type=auth", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, r)
+
+	var errResp ErrorResponse
+	err := json.Unmarshal(w.Body.Bytes(), &errResp)
+	if err != nil {
+		t.Fatal("expected JSON error response")
+	}
+	if errResp.Error != "Bad auth" {
+		t.Fatalf("expected 'Bad auth' error, got '%s'", errResp.Error)
+	}
+}
+
+// Test path traversal is rejected
+func TestPathTraversal(t *testing.T) {
+	// Note: RenderStaticContent tries to open files from /web-content/
+	// which doesn't exist in test. The path validation should reject
+	// traversal attempts before even trying to open the file.
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"parent directory", "../etc/passwd"},
+		{"double traversal", "../../etc/passwd"},
+		{"absolute path", "/etc/passwd"},
+		{"embedded traversal", "public/../../../etc/passwd"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			RenderStaticContent(w, tt.path)
+			// Should return empty/blank response, NOT file contents
+			body := w.Body.String()
+			if strings.Contains(body, "root:") {
+				t.Fatalf("path traversal succeeded for %s", tt.path)
+			}
+		})
+	}
+}
+
+// Test atomic balance query
+func TestAtomicBalance(t *testing.T) {
+	db_conn := openTestDB(t)
+
+	// Insert a card
+	db.Db_insert_card(db_conn, "k0", "k1", "k2", "k3", "k4", "ballogin", "balpass")
+
+	// Get card_id - look it up via access token after setting tokens
+	err := db.Db_set_tokens(db_conn, "ballogin", "balpass", "baltoken", "balrefresh")
+	if err != nil {
+		t.Fatal("failed to set tokens")
+	}
+	card_id := db.Db_get_card_id_from_access_token(db_conn, "baltoken")
+	if card_id == 0 {
+		t.Fatal("expected non-zero card_id")
+	}
+
+	// No transactions, balance should be 0
+	balance := db.Db_get_card_balance(db_conn, card_id)
+	if balance != 0 {
+		t.Fatalf("expected balance 0, got %d", balance)
+	}
+
+	// Add a receipt
+	db.Db_add_card_receipt(db_conn, card_id, "lnbc1...", "abc123", 1000)
+	// Mark it paid
+	db.Db_set_receipt_paid(db_conn, "abc123")
+
+	balance = db.Db_get_card_balance(db_conn, card_id)
+	if balance != 1000 {
+		t.Fatalf("expected balance 1000, got %d", balance)
+	}
+
+	// Add a payment
+	db.Db_add_card_payment(db_conn, card_id, 300, "lnbc2...")
+
+	balance = db.Db_get_card_balance(db_conn, card_id)
+	if balance != 700 {
+		t.Fatalf("expected balance 700, got %d", balance)
+	}
+}

--- a/docker/card/web/websocket.go
+++ b/docker/card/web/websocket.go
@@ -1,8 +1,8 @@
 package web
 
 import (
+	"card/db"
 	"card/phoenix"
-	"card/util"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
@@ -25,106 +25,128 @@ type WebSocketMessage struct {
 	PayerKey    string `json:"payerKey,omitempty"`
 }
 
-func WebsocketHandler(w http.ResponseWriter, r *http.Request) {
+func (app *App) CreateHandler_Websocket() http.HandlerFunc {
+	hostDomain := db.Db_get_setting(app.db_conn, "host_domain")
+	return func(w http.ResponseWriter, r *http.Request) {
 
-	var upgrader = websocket.Upgrader{
-		ReadBufferSize:  1024,
-		WriteBufferSize: 1024,
-		CheckOrigin: func(r *http.Request) bool {
-			return true // TODO: authenticate
-		},
-	}
-
-	conn, err := upgrader.Upgrade(w, r, nil)
-	util.CheckAndPanic(err)
-
-	log.Info("websocket from client is open")
-
-	defer conn.Close()
-
-	// open a websocket connection to phoenix
-	// to receive payment notifications
-	// and pass each one on to the client
-
-	cfg, err := ini.Load("/root/.phoenix/phoenix.conf")
-	util.CheckAndPanic(err)
-
-	hp := cfg.Section("").Key("http-password").String()
-
-	// https://github.com/gorilla/websocket/issues/209#issuecomment-275419998
-	h := http.Header{"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte(":"+hp))}}
-	c, _, err := websocket.DefaultDialer.Dial("ws://phoenix:9740/websocket", h)
-	if err != nil {
-		log.Info("phoenix not available : ", err.Error())
-	} else {
-		defer c.Close()
-
-		done := make(chan struct{})
-
-		go func() {
-			defer close(done)
-			for {
-				_, message, err := c.ReadMessage()
-				if err != nil {
-					log.Info("websocket to phoenix is closing : ", err.Error())
-					return
+		var upgrader = websocket.Upgrader{
+			ReadBufferSize:  1024,
+			WriteBufferSize: 1024,
+			CheckOrigin: func(r *http.Request) bool {
+				origin := r.Header.Get("Origin")
+				if origin == "" {
+					return true // allow non-browser clients
 				}
+				return origin == "https://"+hostDomain
+			},
+		}
 
-				// `message` contains the websocket message as []byte from Phoenix server
-				log.Info("message : ", string(message))
-
-				// decode the JSON into a struct
-				var webSocketMessage WebSocketMessage
-
-				err = json.Unmarshal(message, &webSocketMessage)
-				util.CheckAndPanic(err)
-
-				log.Info("webSocketMessage : ", webSocketMessage)
-
-				// look up the payment_hash to look up the description using GetIncomingPayment
-				incomingPayment, err := phoenix.GetIncomingPayment(webSocketMessage.PaymentHash)
-				util.CheckAndPanic(err)
-
-				log.Info("incomingPayment : ", incomingPayment)
-
-				// TODO: send JSON encoded data to add a tx row
-				// TODO: send JSON encoded data to update the totals
-				now := time.Now()
-				now_string := now.Format("15:04:05")
-				err = conn.WriteMessage(websocket.TextMessage,
-					[]byte(now_string+" UTC, "+
-						strconv.Itoa(incomingPayment.ReceivedSat)+" sats received, "+
-						strconv.Itoa(incomingPayment.Fees)+" sats fees,"+
-						" message: "+webSocketMessage.PayerNote))
-				if err != nil {
-					log.Warning("websocket write error :", err)
-					return
-				}
-			}
-		}()
-	}
-
-	for {
-		// read message from client
-		_, message, err := conn.ReadMessage()
+		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
-			log.Info("websocket from client is closing : ", err.Error())
+			log.Error("websocket upgrade error: ", err)
 			return
 		}
 
-		// handle "ping" message
-		if string(message) == "ping" {
+		log.Info("websocket from client is open")
 
-			//send message to client
-			err = conn.WriteMessage(websocket.TextMessage, []byte("pong"))
-			util.CheckAndPanic(err)
+		defer conn.Close()
 
-			continue
+		// open a websocket connection to phoenix
+		// to receive payment notifications
+		// and pass each one on to the client
+
+		cfg, err := ini.Load("/root/.phoenix/phoenix.conf")
+		if err != nil {
+			log.Error("failed to load phoenix config: ", err)
+			return
 		}
 
-		// TODO: make sure authentication is implemented before adding more here!
+		hp := cfg.Section("").Key("http-password").String()
 
-		// show message if not handled
-		log.Info("websocket from client - unhandled message : ", string(message))
+		// https://github.com/gorilla/websocket/issues/209#issuecomment-275419998
+		h := http.Header{"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte(":"+hp))}}
+		c, _, err := websocket.DefaultDialer.Dial("ws://phoenix:9740/websocket", h)
+		if err != nil {
+			log.Info("phoenix not available : ", err.Error())
+		} else {
+			defer c.Close()
+
+			done := make(chan struct{})
+
+			go func() {
+				defer close(done)
+				for {
+					_, message, err := c.ReadMessage()
+					if err != nil {
+						log.Info("websocket to phoenix is closing : ", err.Error())
+						return
+					}
+
+					// `message` contains the websocket message as []byte from Phoenix server
+					log.Info("message : ", string(message))
+
+					// decode the JSON into a struct
+					var webSocketMessage WebSocketMessage
+
+					err = json.Unmarshal(message, &webSocketMessage)
+					if err != nil {
+						log.Error("websocket json unmarshal error: ", err)
+						return
+					}
+
+					log.Info("webSocketMessage : ", webSocketMessage)
+
+					// look up the payment_hash to look up the description using GetIncomingPayment
+					incomingPayment, err := phoenix.GetIncomingPayment(webSocketMessage.PaymentHash)
+					if err != nil {
+						log.Error("phoenix GetIncomingPayment error: ", err)
+						return
+					}
+
+					log.Info("incomingPayment : ", incomingPayment)
+
+					// TODO: send JSON encoded data to add a tx row
+					// TODO: send JSON encoded data to update the totals
+					now := time.Now()
+					now_string := now.Format("15:04:05")
+					err = conn.WriteMessage(websocket.TextMessage,
+						[]byte(now_string+" UTC, "+
+							strconv.Itoa(incomingPayment.ReceivedSat)+" sats received, "+
+							strconv.Itoa(incomingPayment.Fees)+" sats fees,"+
+							" message: "+webSocketMessage.PayerNote))
+					if err != nil {
+						log.Warning("websocket write error :", err)
+						return
+					}
+				}
+			}()
+		}
+
+		for {
+			// read message from client
+			_, message, err := conn.ReadMessage()
+			if err != nil {
+				log.Info("websocket from client is closing : ", err.Error())
+				return
+			}
+
+			// handle "ping" message
+			if string(message) == "ping" {
+
+				//send message to client
+				err = conn.WriteMessage(websocket.TextMessage, []byte("pong"))
+				if err != nil {
+					log.Error("websocket write error: ", err)
+					return
+				}
+
+				continue
+			}
+
+			// TODO: make sure authentication is implemented before adding more here!
+
+			// show message if not handled
+			log.Info("websocket from client - unhandled message : ", string(message))
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- **Fix auth header crash**: Add `getBearerToken()` helper to safely parse `Authorization` headers, replacing unsafe `splitToken[1]` that panics on missing/malformed headers (9 handlers)
- **Replace CheckAndPanic in HTTP handlers**: Swap `util.CheckAndPanic()` (which calls `panic()`) with proper error handling across all web handler code paths (19 files)
- **Add WebSocket origin validation**: Convert `WebsocketHandler` to `App.CreateHandler_Websocket()` and validate `Origin` header against configured `host_domain`
- **Upgrade password hashing to bcrypt**: Replace single-iteration SHA256 with `bcrypt.DefaultCost`, with transparent migration of existing passwords on login
- **Fix balance race condition**: Add atomic `Db_get_card_balance()` single-query function replacing two separate queries that could allow overdraft between reads
- **Remove secret logging**: Redact invite secrets, batch programming secrets, auth credentials, and tokens from log output
- **Fix path traversal in static file serving**: Sanitize paths with `filepath.Clean` and prefix validation in `RenderStaticContent`
- **Validate HOST_DOMAIN at startup**: Panic with clear message if env var is empty on first-time init (prevents silent misconfiguration)
- **Add web handler tests**: 10 new tests covering auth parsing, balance, path traversal, and atomic balance query
- **Switch runtime base image**: Replace `ubuntu:24.04` with `debian:bookworm-slim` for smaller image size and reduced attack surface (drop-in replacement, both use glibc for CGo/sqlite3 compatibility)

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test -race -count=1 ./...` — all packages pass (crypto, db, web)
- [x] `docker compose build` — both images build
- [ ] Manual: send request without Authorization header → get JSON error (not crash)
- [ ] Manual: attempt `../etc/passwd` path → rejected
- [ ] Manual: login with existing SHA256 password → migrated to bcrypt transparently

🤖 Generated with [Claude Code](https://claude.com/claude-code)