### PR TITLE
Improve README, Docker base image, and socket buffer config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,9 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
       - caddy_config:/config
+    sysctls:
+      - net.core.rmem_max=7500000
+      - net.core.wmem_max=7500000
     networks:
       - hubnet
 networks:

--- a/docker/card/Dockerfile
+++ b/docker/card/Dockerfile
@@ -11,8 +11,8 @@ ENV GOCACHE=/root/.cache/go-build
 RUN --mount=type=cache,target="/root/.cache/go-build" \
     go build -o app -ldflags="-X 'card/build.Date=$(date +"%a %d %b %Y")' -X 'card/build.Time=$(date +"%H:%M:%S %Z")'"
 
-FROM ubuntu:24.04
-RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && rm -rf /var/lib/apt/lists/*
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates sqlite3 && rm -rf /var/lib/apt/lists/*
 RUN mkdir /app
 WORKDIR /app
 COPY --from=builder /app/web-content/ /web-content/


### PR DESCRIPTION
## Summary
- Rewrote README: added project description, fixed install workflow (`.env` instead of `docker_init.sh`), removed unnecessary manual volume creation, clarified DNS setup, fixed typo, added update instructions, cleaned up operations section
- Switched Docker runtime base image from `ubuntu:24.04` to `debian:bookworm-slim` (smaller, glibc compatible)
- Added `sqlite3` to card container image for direct database access via `docker compose exec`
- Moved socket buffer tuning (`rmem_max`/`wmem_max`) from manual host sysctl to `docker-compose.yml` sysctls on webproxy service

## Test plan
- [ ] `docker compose build` succeeds
- [ ] `docker compose exec card sqlite3 /card_data/cards.db` works
- [ ] Caddy no longer logs buffer size warnings
- [ ] README install steps are accurate and complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)