### PR TITLE
Optimize container memory limits for 1GB VPS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256M
+          memory: 384M
     volumes:
       - phoenix_data:/phoenix/.phoenix
     networks:
@@ -18,7 +18,7 @@ services:
     build: ./docker/card
     env_file: .env
     environment:
-      - GOMEMLIMIT=100MiB
+      - GOMEMLIMIT=150MiB
     develop:
       watch:
         - path: ./docker/card
@@ -26,7 +26,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 128M
+          memory: 192M
     depends_on:
       - phoenix
       - webproxy
@@ -54,7 +54,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 128M
+          memory: 192M
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
## Summary
- Redistribute unused OS headroom (~300MB idle) to containers
- phoenix: 256M → 384M (JVM benefits most from extra heap)
- card: 128M → 192M, GOMEMLIMIT 100MiB → 150MiB
- webproxy: 128M → 192M
- Total: 512M → 768M, leaving ~256M for OS (still comfortable for Debian + Docker)

## Test plan
- [ ] `docker compose up -d` starts all containers without OOM kills
- [ ] `docker stats` shows containers within new limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)