### PR TITLE
Add swap setup and stop containers before rebuilding

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ A lightweight, self-hosted service for hosting NFC Bolt Cards on the Lightning N
 - log in to the machine using SSH (Linux) or Putty (Windows)
 - [install docker](https://docs.docker.com/engine/install/debian/)
 - [enable managing docker as a non root user](https://docs.docker.com/engine/install/linux-postinstall/)
+- add swap space (the Go build needs more memory than the 1GB VPS provides)
+
+```bash
+sudo fallocate -l 1G /swapfile
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+```
+
 - set up a DNS A record pointing `hub.yourdomain.com` to the VPS IP address
 
 ```bash
@@ -70,6 +80,7 @@ docker exec -it card bash
 
 ```bash
 git pull
+docker compose down
 docker compose build
 docker compose up -d
 docker system prune


### PR DESCRIPTION
## Summary
- Add 1GB swap file setup to install instructions — the Go/CGo compiler needs more memory than the 1GB VPS provides during `docker compose build`
- Add `docker compose down` before `docker compose build` in the update flow to free container memory for the compiler

## Test plan
- [ ] Verify swap setup commands work on a fresh Debian 12 VPS
- [ ] Verify `docker compose build` succeeds on 1GB VPS with swap enabled
- [ ] Verify update flow (`git pull`, `down`, `build`, `up -d`, `prune`) works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)