### PR TITLE
Clean up redundant imports, deprecated calls, and dead code

### DIFF
--- a/docker/card/cli.go
+++ b/docker/card/cli.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/docker/card/db/db_add.go
+++ b/docker/card/db/db_add.go
@@ -3,8 +3,6 @@ package db
 import (
 	"card/util"
 	"database/sql"
-
-	_ "github.com/mattn/go-sqlite3"
 )
 
 func Db_add_card_receipt(db_conn *sql.DB, card_id int, payment_request string, payment_hash_hex string, amount_sats int) (card_receipt_id int) {

--- a/docker/card/db/db_close.go
+++ b/docker/card/db/db_close.go
@@ -3,8 +3,6 @@ package db
 import (
 	"card/util"
 	"database/sql"
-
-	_ "github.com/mattn/go-sqlite3"
 )
 
 func Close(db *sql.DB) {

--- a/docker/card/db/db_create.go
+++ b/docker/card/db/db_create.go
@@ -3,7 +3,6 @@ package db
 import (
 	"database/sql"
 
-	_ "github.com/mattn/go-sqlite3"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/docker/card/db/db_get.go
+++ b/docker/card/db/db_get.go
@@ -3,8 +3,6 @@ package db
 import (
 	"card/util"
 	"database/sql"
-
-	_ "github.com/mattn/go-sqlite3"
 )
 
 func Db_get_setting(db_conn *sql.DB, name string) string {

--- a/docker/card/db/db_insert.go
+++ b/docker/card/db/db_insert.go
@@ -3,8 +3,6 @@ package db
 import (
 	"card/util"
 	"database/sql"
-
-	_ "github.com/mattn/go-sqlite3"
 )
 
 func Db_insert_card(db_conn *sql.DB, key0 string, key1 string, k2 string, key3 string, key4 string,

--- a/docker/card/db/db_select.go
+++ b/docker/card/db/db_select.go
@@ -3,8 +3,6 @@ package db
 import (
 	"card/util"
 	"database/sql"
-
-	_ "github.com/mattn/go-sqlite3"
 )
 
 type CardReceipt struct {

--- a/docker/card/db/db_set.go
+++ b/docker/card/db/db_set.go
@@ -4,8 +4,6 @@ import (
 	"card/util"
 	"database/sql"
 	"errors"
-
-	_ "github.com/mattn/go-sqlite3"
 )
 
 func Db_set_setting(db_conn *sql.DB, name string, value string) {

--- a/docker/card/db/db_test.go
+++ b/docker/card/db/db_test.go
@@ -4,8 +4,6 @@ import (
 	"database/sql"
 	"os"
 	"testing"
-
-	_ "github.com/mattn/go-sqlite3"
 )
 
 func openTestDB(t *testing.T) *sql.DB {

--- a/docker/card/db/db_test_data.go
+++ b/docker/card/db/db_test_data.go
@@ -2,8 +2,6 @@ package db
 
 import (
 	"database/sql"
-
-	_ "github.com/mattn/go-sqlite3"
 )
 
 func add_test_data(db_conn *sql.DB) {

--- a/docker/card/db/db_update.go
+++ b/docker/card/db/db_update.go
@@ -3,8 +3,6 @@ package db
 import (
 	"card/util"
 	"database/sql"
-
-	_ "github.com/mattn/go-sqlite3"
 )
 
 func Db_update_tokens(db_conn *sql.DB, initial_refresh_token string, new_refresh_token string, access_token string) (success bool) {

--- a/docker/card/db/db_wipe.go
+++ b/docker/card/db/db_wipe.go
@@ -3,8 +3,6 @@ package db
 import (
 	"card/util"
 	"database/sql"
-
-	_ "github.com/mattn/go-sqlite3"
 )
 
 type CardKeys struct {

--- a/docker/card/main.go
+++ b/docker/card/main.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/docker/card/phoenix/client.go
+++ b/docker/card/phoenix/client.go
@@ -46,7 +46,7 @@ func doRequest(req *http.Request, timeout time.Duration, endpointName string) ([
 	}
 
 	if res.StatusCode != 200 {
-		log.Warning(endpointName, " StatusCode ", res.StatusCode)
+		log.Warn(endpointName, " StatusCode ", res.StatusCode)
 		return nil, errors.New("failed API call to Phoenix " + endpointName)
 	}
 

--- a/docker/card/phoenix/send_lightning_payment.go
+++ b/docker/card/phoenix/send_lightning_payment.go
@@ -42,7 +42,7 @@ func SendLightningPayment(
 
 	password, err := loadPassword()
 	if err != nil {
-		log.Warning(err)
+		log.Warn(err)
 		return sendLightningPaymentResponse,
 			"no_config",
 			errors.New("could not load config for SendLightningPayment")
@@ -56,7 +56,7 @@ func SendLightningPayment(
 
 	req, err := http.NewRequest(http.MethodPost, phoenixBaseURL+"/payinvoice", reader)
 	if err != nil {
-		log.Warning(err)
+		log.Warn(err)
 		return sendLightningPaymentResponse,
 			"failed_request_creation",
 			errors.New("could not create request for SendLightningPayment")
@@ -90,7 +90,7 @@ func SendLightningPayment(
 	}
 
 	if res.StatusCode != 200 {
-		log.Warning("SendLightningPayment StatusCode ", res.StatusCode, "ResBody", string(resBody))
+		log.Warn("SendLightningPayment StatusCode ", res.StatusCode, "ResBody", string(resBody))
 		return sendLightningPaymentResponse,
 			"fail_status_code",
 			errors.New("fail status code returned for SendLightningPayment")

--- a/docker/card/util/utils.go
+++ b/docker/card/util/utils.go
@@ -41,16 +41,6 @@ func Random_hex() string {
 	return hex.EncodeToString(b)
 }
 
-func Max(a, b int) int {
-	var max int
-	if a > b {
-		max = a
-	} else {
-		max = b
-	}
-	return max
-}
-
 func QrPngBase64Encode(data string) (encoded string) {
 	var data_qr_png []byte
 	data_qr_png, err := qrcode.Encode(data, qrcode.Medium, 256)

--- a/docker/card/web/admin_handler.go
+++ b/docker/card/web/admin_handler.go
@@ -13,8 +13,6 @@ func (app *App) CreateHandler_Admin() http.HandlerFunc {
 
 		request := r.RequestURI
 
-		//log.Info("CreateHandler_Admin handler with request uri : " + request)
-
 		// prevent caching
 		w.Header().Add("Cache-Control", "no-cache, no-store")
 

--- a/docker/card/web/pos_api_addinvoice.go
+++ b/docker/card/web/pos_api_addinvoice.go
@@ -32,9 +32,6 @@ func (app *App) CreateHandler_PosApi_AddInvoice() http.HandlerFunc {
 
 		log.Info("pos_api AddInvoice request received")
 
-		// reqToken := r.Header.Get("Authorization")
-		// log.Info("auth token : ", reqToken)
-
 		// get details from request body
 
 		decoder := json.NewDecoder(r.Body)

--- a/docker/card/web/public_handler.go
+++ b/docker/card/web/public_handler.go
@@ -10,7 +10,6 @@ func (app *App) CreateHandler_Public() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 
 		request := r.RequestURI
-		//log.Info("CreateHandler_Public handler with request uri : " + request)
 
 		w.Header().Add("Cache-Control", "max-age=60, must-revalidate")
 

--- a/docker/card/web/render.go
+++ b/docker/card/web/render.go
@@ -35,7 +35,6 @@ func visit(path string, di fs.DirEntry, err error) error {
 
 	// load the template cache
 	if strings.HasSuffix(template_name, ".html") {
-		//log.Info("loading template cache: " + template_full_name + " : from : " + path)
 		ts, err := template.New(template_name).ParseFiles(path)
 		if err != nil {
 			log.Error("template parse error: ", err)
@@ -90,7 +89,7 @@ func RenderStaticContent(w http.ResponseWriter, request string) {
 
 	switch {
 	case strings.HasSuffix(request, ".js"):
-		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("Content-Type", "application/javascript")
 	case strings.HasSuffix(request, ".css"):
 		w.Header().Add("Content-Type", "text/css")
 	case strings.HasSuffix(request, ".png"):

--- a/docker/card/web/wallet_api_payinvoice.go
+++ b/docker/card/web/wallet_api_payinvoice.go
@@ -2,9 +2,7 @@ package web
 
 import (
 	"card/db"
-
 	"card/phoenix"
-	"card/util"
 	"encoding/json"
 	"net/http"
 	"strconv"
@@ -56,7 +54,7 @@ func (app *App) CreateHandler_WalletApi_PayInvoice() http.HandlerFunc {
 			return
 		}
 
-		actualAmtSat := util.Max(invAmtSat, reqObj.Amount)
+		actualAmtSat := max(invAmtSat, reqObj.Amount)
 
 		// check if there is sufficient balance (atomic query)
 

--- a/docker/card/web/websocket.go
+++ b/docker/card/web/websocket.go
@@ -115,7 +115,7 @@ func (app *App) CreateHandler_Websocket() http.HandlerFunc {
 							strconv.Itoa(incomingPayment.Fees)+" sats fees,"+
 							" message: "+webSocketMessage.PayerNote))
 					if err != nil {
-						log.Warning("websocket write error :", err)
+						log.Warn("websocket write error :", err)
 						return
 					}
 				}


### PR DESCRIPTION
## Summary
- Remove redundant `go-sqlite3` driver imports from 13 files (only needed once in `db_init.go`)
- Fix deprecated `log.Warning` → `log.Warn` (5 call sites in phoenix and websocket packages)
- Fix JS Content-Type from `application/json` to `application/javascript` in static file serving
- Replace custom `util.Max` with Go builtin `max`, delete the now-unused function
- Remove commented-out debug logging code (4 blocks)

## Test plan
- [x] `go vet ./...` passes
- [x] `go test -race -count=1 ./...` passes (crypto, db, web)
- [ ] Verify static JS files served with correct Content-Type in browser dev tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)