### PR TITLE
fix: upgrade phoenixd to 0.8.0 to fix small-payment routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ docker exec -it card bash
 
 ### Docker Services (docker-compose.yml)
 
-- **phoenix**: acinq/phoenixd:0.7.2 — Lightning node (384M memory)
+- **phoenix**: acinq/phoenixd:0.8.0 — Lightning node (384M memory)
 - **card**: Custom Go app — card service on `:8000` (192M memory, GOMEMLIMIT=150MiB). Has Docker healthcheck (HEAD / every 30s). Graceful shutdown on SIGTERM with 10s drain timeout. Includes `sqlite3` for database access. Mounts Docker socket for admin update feature.
 - **webproxy**: Custom Caddy build (via xcaddy with `caddy-ratelimit` plugin) — reverse proxy with auto-TLS, CORS, zstd compression, and rate limiting on auth endpoints (10 req/min per IP on `/admin/login/`, `/auth`, `/admin/api/auth/login`)
 
@@ -154,6 +154,8 @@ The `settings` table stores key-value config. Active settings used by the app:
 - `schema_version_number` — tracks database migration state
 
 Withdraw limits (`min_withdraw_sats=1`, `max_withdraw_sats=100000000`) are hardcoded in `lnurlw_request.go` and `lnurlw_callback.go`, not stored in the database.
+
+> **Note (Phoenix routing fees):** the hub does *not* send a fee cap to phoenixd — `phoenix/send_lightning_payment.go` posts only `amountSat` + `invoice` to `/payinvoice`, so phoenixd applies its own default fee budget. The `max_network_fee_sats` value (`4 + amountSats*4/1000` in `lnurlw_callback.go`) is used only to reserve card balance, not as the payment fee ceiling. This bit us once: phoenixd 0.7.3 (lightning-kmp 1.11) couldn't route tiny ~20–250 sat payments within its default budget and rejected them with `"routing fees are insufficient"`; upgrading to 0.8.0 (lightning-kmp 1.12.0) fixed it. **Possible future hardening (may never be needed):** pass an explicit `maxFeeFlatSat` (sats) to `/payinvoice` — e.g. a `5 + amountSats*4/1000` floor — so the hub controls the fee budget instead of relying on phoenixd defaults.
 
 The admin settings page (`/admin/settings/`) displays all settings with sensitive values (`_hash`, `_token`, `_code` suffixes) redacted. `log_level` has an inline dropdown that submits on change.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   phoenix:
     container_name: phoenix
-    image: acinq/phoenixd:0.7.2
+    image: acinq/phoenixd:0.8.0
     restart: unless-stopped
     deploy:
       resources:


### PR DESCRIPTION
## Problem

After phoenixd was upgraded `0.7.2` → `0.7.3` (lightning-kmp 1.11), **every card purchase failed**. phoenixd could not route tiny LNURL-withdraw payments (~20–250 sats) within its default fee budget and rejected them with `"routing fees are insufficient"`. The last successful payment was pre-upgrade; 10/10 attempts on the day of investigation failed (amounts 21–213 sats), while card balances were fine.

## Root cause

The hub never sends a fee cap to phoenixd — `phoenix/send_lightning_payment.go` posts only `amountSat` + `invoice` to `/payinvoice`, so phoenixd applies its **own default fee budget**. phoenixd 0.7.3's routing engine couldn't find a route for these small amounts within that default.

## Fix

Upgrade phoenixd to **0.8.0** (lightning-kmp 1.12.0). Verified in production with a live card tap: a **22-sat** payment — the exact amount that was failing on 0.7.3 — now routes successfully with a **4-sat** routing fee.

## Changes

- `docker-compose.yml`: `acinq/phoenixd:0.7.3` → `0.8.0`
- `CLAUDE.md`: bump documented phoenixd version, and add a note explaining that the hub relies on phoenixd's default fee budget — plus a possible future hardening (pass an explicit `maxFeeFlatSat` to `/payinvoice`) if small-payment rejections ever recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)