### PR TITLE
Add test coverage for phoenix, util, db, and CLI packages

### DIFF
--- a/docker/card/cli_test.go
+++ b/docker/card/cli_test.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"card/db"
+	"database/sql"
+	"os"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func openCliTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	os.Setenv("HOST_DOMAIN", "test.example.com")
+	conn, err := sql.Open("sqlite3", ":memory:?_foreign_keys=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	db.Db_init(conn)
+	return conn
+}
+
+func TestGetBalance_SumsTxs(t *testing.T) {
+	conn := openCliTestDB(t)
+	db.Db_insert_card(conn, "k0", "k1", "k2", "k3", "k4", "login1", "pass")
+
+	// paid receipt of 1000, paid payment of 200 (+10 fee)
+	db.Db_add_card_receipt(conn, 1, "inv", "h1", 1000)
+	db.Db_set_receipt_paid(conn, "h1", "test")
+	payId := db.Db_add_card_payment(conn, 1, 200, "p1")
+	db.Db_update_card_payment_fee(conn, payId, 10)
+
+	// getBalance sums signed amounts from Db_select_card_txs:
+	// receipt +1000, payment -(200) -(10) = 790
+	if bal := getBalance(conn, 1); bal != 790 {
+		t.Fatalf("expected balance 790, got %d", bal)
+	}
+}
+
+func TestSetupCardAmountForTag_LoadsCards(t *testing.T) {
+	conn := openCliTestDB(t)
+	db.Db_insert_card_with_uid(conn, "k0", "k1", "k2", "k3", "k4", "l1", "p1", "uid1", "event1")
+	db.Db_insert_card_with_uid(conn, "k0", "k1", "k2", "k3", "k4", "l2", "p2", "uid2", "event1")
+
+	setupCardAmountForTag(conn, []string{"SetupCardAmountForTag", "event1", "5000"})
+
+	for _, cardId := range []int{1, 2} {
+		if bal := getBalance(conn, cardId); bal != 5000 {
+			t.Fatalf("card %d: expected balance 5000, got %d", cardId, bal)
+		}
+	}
+}
+
+func TestSetupCardAmountForTag_MissingArgs(t *testing.T) {
+	conn := openCliTestDB(t)
+	// should return without panicking when amount is missing
+	setupCardAmountForTag(conn, []string{"SetupCardAmountForTag", "event1"})
+}
+
+func TestSetupCardAmountForTag_InvalidAmount(t *testing.T) {
+	conn := openCliTestDB(t)
+	db.Db_insert_card_with_uid(conn, "k0", "k1", "k2", "k3", "k4", "l1", "p1", "uid1", "event1")
+	setupCardAmountForTag(conn, []string{"SetupCardAmountForTag", "event1", "notanumber"})
+	// invalid amount -> no receipt added -> balance stays 0
+	if bal := getBalance(conn, 1); bal != 0 {
+		t.Fatalf("expected balance 0 after invalid amount, got %d", bal)
+	}
+}
+
+func TestSetupCardAmountForTag_SkipsCardWithExistingReceipts(t *testing.T) {
+	conn := openCliTestDB(t)
+	db.Db_insert_card_with_uid(conn, "k0", "k1", "k2", "k3", "k4", "l1", "p1", "uid1", "event1")
+
+	// give the card an existing paid receipt
+	db.Db_add_card_receipt(conn, 1, "inv", "h1", 999)
+	db.Db_set_receipt_paid(conn, "h1", "test")
+
+	// setup should bail (logs error) and not add another receipt
+	setupCardAmountForTag(conn, []string{"SetupCardAmountForTag", "event1", "5000"})
+
+	if bal := getBalance(conn, 1); bal != 999 {
+		t.Fatalf("expected untouched balance 999, got %d", bal)
+	}
+}
+
+func TestClearCardBalancesForTag_ZeroesBalances(t *testing.T) {
+	conn := openCliTestDB(t)
+	db.Db_insert_card_with_uid(conn, "k0", "k1", "k2", "k3", "k4", "l1", "p1", "uid1", "event1")
+
+	// load the card with 3000
+	setupCardAmountForTag(conn, []string{"SetupCardAmountForTag", "event1", "3000"})
+	if bal := getBalance(conn, 1); bal != 3000 {
+		t.Fatalf("setup precondition failed, balance %d", bal)
+	}
+
+	clearCardBalancesForTag(conn, []string{"ClearCardBalancesForTag", "event1"})
+	if bal := getBalance(conn, 1); bal > 0 {
+		t.Fatalf("expected balance <= 0 after clear, got %d", bal)
+	}
+}
+
+func TestClearCardBalancesForTag_MissingArgs(t *testing.T) {
+	conn := openCliTestDB(t)
+	clearCardBalancesForTag(conn, []string{"ClearCardBalancesForTag"})
+}
+
+func TestProgramBatch_InsertsProgramCard(t *testing.T) {
+	conn := openCliTestDB(t)
+
+	programBatch(conn, []string{"ProgramBatch", "batch1", "10", "5000", "24"})
+
+	var count int
+	if err := conn.QueryRow("SELECT COUNT(*) FROM program_cards WHERE group_tag='batch1'").Scan(&count); err != nil {
+		t.Fatalf("query error: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 program_cards row, got %d", count)
+	}
+}
+
+func TestProgramBatch_WrongArgCount(t *testing.T) {
+	conn := openCliTestDB(t)
+	programBatch(conn, []string{"ProgramBatch", "batch1", "10"})
+
+	var count int
+	conn.QueryRow("SELECT COUNT(*) FROM program_cards").Scan(&count)
+	if count != 0 {
+		t.Fatalf("expected no rows for wrong arg count, got %d", count)
+	}
+}
+
+func TestProgramBatch_InvalidNumbers(t *testing.T) {
+	conn := openCliTestDB(t)
+	programBatch(conn, []string{"ProgramBatch", "batch1", "notnum", "5000", "24"})
+
+	var count int
+	conn.QueryRow("SELECT COUNT(*) FROM program_cards").Scan(&count)
+	if count != 0 {
+		t.Fatalf("expected no rows for invalid max_group_num, got %d", count)
+	}
+}
+
+func TestWipeCard_WrongArgCount(t *testing.T) {
+	conn := openCliTestDB(t)
+	// should not panic
+	wipeCard(conn, []string{"WipeCard"})
+}
+
+func TestWipeCard_InvalidId(t *testing.T) {
+	conn := openCliTestDB(t)
+	wipeCard(conn, []string{"WipeCard", "notanumber"})
+}
+
+func TestWipeCard_ZeroId(t *testing.T) {
+	conn := openCliTestDB(t)
+	wipeCard(conn, []string{"WipeCard", "0"})
+}
+
+func TestWipeCard_ValidCard(t *testing.T) {
+	conn := openCliTestDB(t)
+	db.Db_insert_card(conn, "k0", "k1", "k2", "k3", "k4", "login1", "pass")
+
+	// wipeCard prints the wipe JSON for a valid, non-wiped card; it must not panic
+	wipeCard(conn, []string{"WipeCard", "1"})
+
+	// the CLI wipeCard only displays data; it does not mark the card wiped,
+	// so the card should still be retrievable and not wiped
+	card, err := db.Db_get_card(conn, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if card.Wiped != "N" {
+		t.Fatalf("expected card still not wiped, got %q", card.Wiped)
+	}
+}
+
+func TestProcessArgs_UnknownCommand(t *testing.T) {
+	conn := openCliTestDB(t)
+	// unknown command hits the default branch and just logs a warning
+	processArgs(conn, []string{"NopeNotACommand"})
+}
+
+func TestProcessArgs_DispatchesProgramBatch(t *testing.T) {
+	conn := openCliTestDB(t)
+	processArgs(conn, []string{"ProgramBatch", "batchX", "5", "1000", "12"})
+
+	var count int
+	conn.QueryRow("SELECT COUNT(*) FROM program_cards WHERE group_tag='batchX'").Scan(&count)
+	if count != 1 {
+		t.Fatalf("expected ProgramBatch dispatch to insert 1 row, got %d", count)
+	}
+}

--- a/docker/card/db/db_more_test.go
+++ b/docker/card/db/db_more_test.go
@@ -1,0 +1,290 @@
+package db
+
+import (
+	"database/sql"
+	"testing"
+)
+
+// helper: insert a card and return its id (cards are auto-increment from 1)
+func insertTestCard(t *testing.T, db *sql.DB, login string) {
+	t.Helper()
+	Db_insert_card(db, "k0", "k1", "k2", "k3", "k4", login, "pass")
+}
+
+func TestDbSelectCardPayments_OrderedAndEmpty(t *testing.T) {
+	db := openTestDB(t)
+	Db_init(db)
+
+	// no card -> empty
+	if got := Db_select_card_payments(db, 1); len(got) != 0 {
+		t.Fatalf("expected no payments, got %d", len(got))
+	}
+
+	insertTestCard(t, db, "login1")
+	p1 := Db_add_card_payment(db, 1, 100, "inv1")
+	Db_update_card_payment_fee(db, p1, 5)
+	Db_add_card_payment(db, 1, 200, "inv2")
+
+	payments := Db_select_card_payments(db, 1)
+	if len(payments) != 2 {
+		t.Fatalf("expected 2 payments, got %d", len(payments))
+	}
+	// ordered by card_payment_id DESC, so newest (inv2) first
+	if payments[0].AmountSats != 200 {
+		t.Fatalf("expected newest payment first (200), got %d", payments[0].AmountSats)
+	}
+	if payments[1].AmountSats != 100 || payments[1].FeeSats != 5 {
+		t.Fatalf("expected second payment 100/fee 5, got %d/%d", payments[1].AmountSats, payments[1].FeeSats)
+	}
+}
+
+func TestDbSelectCardReceipts_LimitAndAll(t *testing.T) {
+	db := openTestDB(t)
+	Db_init(db)
+	insertTestCard(t, db, "login1")
+
+	Db_add_card_receipt(db, 1, "lnbc1", "h1", 1000)
+	Db_add_card_receipt(db, 1, "lnbc2", "h2", 2000)
+	Db_add_card_receipt(db, 1, "lnbc3", "h3", 3000)
+
+	all := Db_select_card_receipts(db, 1, 0)
+	if len(all) != 3 {
+		t.Fatalf("expected 3 receipts with limit 0, got %d", len(all))
+	}
+	// ordered DESC by id -> newest (h3) first
+	if all[0].PaymentHash != "h3" {
+		t.Fatalf("expected newest receipt first (h3), got %q", all[0].PaymentHash)
+	}
+
+	limited := Db_select_card_receipts(db, 1, 2)
+	if len(limited) != 2 {
+		t.Fatalf("expected 2 receipts with limit 2, got %d", len(limited))
+	}
+	if limited[0].PaymentHash != "h3" || limited[1].PaymentHash != "h2" {
+		t.Fatalf("unexpected limited ordering: %q, %q", limited[0].PaymentHash, limited[1].PaymentHash)
+	}
+}
+
+func TestDbSelectAllCards_ExcludesWipedAndComputesBalance(t *testing.T) {
+	db := openTestDB(t)
+	Db_init(db)
+
+	// empty
+	if got := Db_select_all_cards(db); len(got) != 0 {
+		t.Fatalf("expected no cards, got %d", len(got))
+	}
+
+	insertTestCard(t, db, "login1")
+	insertTestCard(t, db, "login2")
+
+	// card 1 has a paid receipt of 1000 and a paid payment of 200
+	Db_add_card_receipt(db, 1, "lnbc1", "h1", 1000)
+	Db_set_receipt_paid(db, "h1", "test")
+	Db_add_card_payment(db, 1, 200, "inv1")
+
+	// wipe card 2
+	Db_wipe_card(db, 2)
+
+	cards := Db_select_all_cards(db)
+	if len(cards) != 1 {
+		t.Fatalf("expected 1 non-wiped card, got %d", len(cards))
+	}
+	if cards[0].CardId != 1 {
+		t.Fatalf("expected card id 1, got %d", cards[0].CardId)
+	}
+	if cards[0].BalanceSats != 800 {
+		t.Fatalf("expected balance 800 (1000-200), got %d", cards[0].BalanceSats)
+	}
+}
+
+func TestDbSelectAllSettings_Ordered(t *testing.T) {
+	db := openTestDB(t)
+	Db_init(db)
+
+	Db_set_setting(db, "zzz_key", "z")
+	Db_set_setting(db, "aaa_key", "a")
+
+	settings := Db_select_all_settings(db)
+	if len(settings) == 0 {
+		t.Fatal("expected settings, got none")
+	}
+
+	// verify our two keys are present and the list is sorted by name
+	var prev string
+	foundA, foundZ := false, false
+	for _, s := range settings {
+		if prev != "" && s.Name < prev {
+			t.Fatalf("settings not sorted: %q came after %q", s.Name, prev)
+		}
+		prev = s.Name
+		if s.Name == "aaa_key" {
+			foundA = true
+			if s.Value != "a" {
+				t.Fatalf("aaa_key value = %q, want a", s.Value)
+			}
+		}
+		if s.Name == "zzz_key" {
+			foundZ = true
+		}
+	}
+	if !foundA || !foundZ {
+		t.Fatalf("expected both inserted settings present (a=%v z=%v)", foundA, foundZ)
+	}
+}
+
+func TestDbGetTotalCardBalance(t *testing.T) {
+	db := openTestDB(t)
+	Db_init(db)
+
+	if got := Db_get_total_card_balance(db); got != 0 {
+		t.Fatalf("expected 0 total balance, got %d", got)
+	}
+
+	insertTestCard(t, db, "login1")
+	insertTestCard(t, db, "login2")
+
+	// both cards lnurlw_enable defaults to 'Y'
+	Db_add_card_receipt(db, 1, "lnbc1", "h1", 1000)
+	Db_set_receipt_paid(db, "h1", "test")
+	Db_add_card_receipt(db, 2, "lnbc2", "h2", 500)
+	Db_set_receipt_paid(db, "h2", "test")
+	Db_add_card_payment(db, 1, 200, "inv1")
+
+	// total = (1000 - 200) + 500 = 1300
+	if got := Db_get_total_card_balance(db); got != 1300 {
+		t.Fatalf("expected total balance 1300, got %d", got)
+	}
+}
+
+func TestDbGetTableCounts(t *testing.T) {
+	db := openTestDB(t)
+	Db_init(db)
+	insertTestCard(t, db, "login1")
+	Db_add_card_receipt(db, 1, "lnbc1", "h1", 1000)
+
+	counts, err := Db_get_table_counts(db)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	byName := make(map[string]int)
+	for _, c := range counts {
+		byName[c.Name] = c.Count
+	}
+	if byName["cards"] != 1 {
+		t.Fatalf("expected 1 card, got %d", byName["cards"])
+	}
+	if byName["card_receipts"] != 1 {
+		t.Fatalf("expected 1 receipt, got %d", byName["card_receipts"])
+	}
+	if _, ok := byName["settings"]; !ok {
+		t.Fatal("expected settings table in counts")
+	}
+}
+
+func TestDbGetCardNoteByInvoice(t *testing.T) {
+	db := openTestDB(t)
+	Db_init(db)
+	insertTestCard(t, db, "login1")
+	Db_update_card_note(db, 1, "Alice card")
+
+	// unpaid payment -> no note returned
+	Db_add_card_payment(db, 1, 100, "inv_unpaid")
+	Db_update_card_payment_unpaid(db, 1)
+	if got := Db_get_card_note_by_invoice(db, "inv_unpaid"); got != "" {
+		t.Fatalf("expected empty note for unpaid payment, got %q", got)
+	}
+
+	// paid payment (default paid_flag='Y') -> note returned
+	Db_add_card_payment(db, 1, 100, "inv_paid")
+	if got := Db_get_card_note_by_invoice(db, "inv_paid"); got != "Alice card" {
+		t.Fatalf("expected note 'Alice card', got %q", got)
+	}
+
+	// unknown invoice -> empty
+	if got := Db_get_card_note_by_invoice(db, "does_not_exist"); got != "" {
+		t.Fatalf("expected empty note for unknown invoice, got %q", got)
+	}
+}
+
+func TestDbGetCardLnurlwEnable(t *testing.T) {
+	db := openTestDB(t)
+	Db_init(db)
+	insertTestCard(t, db, "login1")
+
+	// default enabled
+	if got := Db_get_card_lnurlw_enable(db, 1); got != "Y" {
+		t.Fatalf("expected default lnurlw_enable 'Y', got %q", got)
+	}
+
+	Db_update_card_without_pin(db, 1, 1000, 5000, "N", 0, "N")
+	if got := Db_get_card_lnurlw_enable(db, 1); got != "N" {
+		t.Fatalf("expected lnurlw_enable 'N' after update, got %q", got)
+	}
+
+	// missing card -> empty
+	if got := Db_get_card_lnurlw_enable(db, 999); got != "" {
+		t.Fatalf("expected empty for missing card, got %q", got)
+	}
+}
+
+func TestDbUpdateCardWithPin(t *testing.T) {
+	db := openTestDB(t)
+	Db_init(db)
+	insertTestCard(t, db, "login1")
+
+	Db_update_card_with_pin(db, 1, 1234, 5678, "Y", "4321", 999, "Y")
+
+	// verify a couple of the written columns via existing getters / raw query
+	var txLimit, dayLimit, pinLimit int
+	var pinEnable, pinNumber, lnurlw string
+	row := db.QueryRow(`SELECT tx_limit_sats, day_limit_sats, pin_enable, pin_number, pin_limit_sats, lnurlw_enable FROM cards WHERE card_id=1`)
+	if err := row.Scan(&txLimit, &dayLimit, &pinEnable, &pinNumber, &pinLimit, &lnurlw); err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+	if txLimit != 1234 || dayLimit != 5678 || pinEnable != "Y" || pinNumber != "4321" || pinLimit != 999 || lnurlw != "Y" {
+		t.Fatalf("unexpected row after Db_update_card_with_pin: %d %d %q %q %d %q",
+			txLimit, dayLimit, pinEnable, pinNumber, pinLimit, lnurlw)
+	}
+}
+
+func TestDbUpdateCardWithoutPin_LeavesPinNumber(t *testing.T) {
+	db := openTestDB(t)
+	Db_init(db)
+	insertTestCard(t, db, "login1")
+
+	// set a pin first
+	Db_update_card_with_pin(db, 1, 10, 20, "Y", "1111", 50, "Y")
+	// update without pin should not touch pin_number
+	Db_update_card_without_pin(db, 1, 30, 40, "N", 60, "N")
+
+	var pinNumber, pinEnable string
+	var txLimit int
+	row := db.QueryRow(`SELECT pin_number, pin_enable, tx_limit_sats FROM cards WHERE card_id=1`)
+	if err := row.Scan(&pinNumber, &pinEnable, &txLimit); err != nil {
+		t.Fatalf("scan error: %v", err)
+	}
+	if pinNumber != "1111" {
+		t.Fatalf("expected pin_number preserved as 1111, got %q", pinNumber)
+	}
+	if pinEnable != "N" || txLimit != 30 {
+		t.Fatalf("expected pin_enable N / tx_limit 30, got %q / %d", pinEnable, txLimit)
+	}
+}
+
+func TestDbUpdateReceiptPaid(t *testing.T) {
+	db := openTestDB(t)
+	Db_init(db)
+	insertTestCard(t, db, "login1")
+
+	rid := Db_add_card_receipt(db, 1, "lnbc1", "h1", 1000)
+	// before: not counted toward balance
+	if bal := Db_get_card_balance(db, 1); bal != 0 {
+		t.Fatalf("expected balance 0 before receipt paid, got %d", bal)
+	}
+
+	Db_update_receipt_paid(db, rid)
+	if bal := Db_get_card_balance(db, 1); bal != 1000 {
+		t.Fatalf("expected balance 1000 after receipt paid, got %d", bal)
+	}
+}

--- a/docker/card/phoenix/client.go
+++ b/docker/card/phoenix/client.go
@@ -12,7 +12,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const phoenixBaseURL = "http://phoenix:9740"
+// phoenixBaseURL is the base URL for the Phoenix Server API. It is a var
+// (not a const) so tests can point it at an httptest.Server.
+var phoenixBaseURL = "http://phoenix:9740"
+
 const defaultTimeout = 5 * time.Second
 
 var (

--- a/docker/card/phoenix/phoenix_test.go
+++ b/docker/card/phoenix/phoenix_test.go
@@ -1,0 +1,387 @@
+package phoenix
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// primePassword marks the sync.Once as done so InitPassword never tries to
+// read the real config file, and sets a known cached password for tests.
+func primePassword(pw string) {
+	passwordOnce.Do(func() {})
+	cachedPassword = pw
+	passwordErr = nil
+}
+
+// withTestServer points phoenixBaseURL at a test server for the duration of a
+// test and primes a non-empty password. The previous base URL is restored on
+// cleanup.
+func withTestServer(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+	primePassword("testpass")
+	srv := httptest.NewServer(handler)
+	old := phoenixBaseURL
+	phoenixBaseURL = srv.URL
+	t.Cleanup(func() {
+		phoenixBaseURL = old
+		srv.Close()
+	})
+}
+
+func TestGetBalance_Success(t *testing.T) {
+	withTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/getbalance" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		// Phoenix uses HTTP basic auth with empty username + password.
+		_, pw, ok := r.BasicAuth()
+		if !ok || pw != "testpass" {
+			t.Errorf("expected basic auth with testpass, got ok=%v pw=%q", ok, pw)
+		}
+		w.Write([]byte(`{"balanceSat":12345,"feeCreditSat":67}`))
+	})
+
+	bal, err := GetBalance()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bal.BalanceSat != 12345 || bal.FeeCreditSat != 67 {
+		t.Fatalf("unexpected balance: %+v", bal)
+	}
+}
+
+func TestGetBalance_Non200(t *testing.T) {
+	withTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("boom"))
+	})
+
+	_, err := GetBalance()
+	if err == nil {
+		t.Fatal("expected error on non-200 response")
+	}
+}
+
+func TestGetBalance_PasswordEmpty(t *testing.T) {
+	// prime an empty password to exercise the getPassword failure path
+	primePassword("")
+	defer primePassword("testpass")
+
+	_, err := GetBalance()
+	if err == nil {
+		t.Fatal("expected error when password is empty")
+	}
+}
+
+func TestCreateInvoice_WithDescription(t *testing.T) {
+	withTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/createinvoice" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse form: %v", err)
+		}
+		if r.PostForm.Get("description") != "coffee" {
+			t.Errorf("expected description=coffee, got %q", r.PostForm.Get("description"))
+		}
+		if r.PostForm.Has("descriptionHash") {
+			t.Errorf("descriptionHash should not be set when Description is used")
+		}
+		if r.PostForm.Get("amountSat") != "1000" {
+			t.Errorf("expected amountSat=1000, got %q", r.PostForm.Get("amountSat"))
+		}
+		w.Write([]byte(`{"amountSat":1000,"paymentHash":"abc","serialized":"lnbc1..."}`))
+	})
+
+	resp, err := CreateInvoice(CreateInvoiceRequest{
+		Description: "coffee",
+		AmountSat:   "1000",
+		ExternalId:  "card-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.PaymentHash != "abc" || resp.Serialized != "lnbc1..." || resp.AmountSat != 1000 {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestCreateInvoice_WithDescriptionHash(t *testing.T) {
+	withTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse form: %v", err)
+		}
+		if r.PostForm.Get("descriptionHash") != "deadbeef" {
+			t.Errorf("expected descriptionHash=deadbeef, got %q", r.PostForm.Get("descriptionHash"))
+		}
+		if r.PostForm.Has("description") {
+			t.Errorf("description should not be set when DescriptionHash is used")
+		}
+		w.Write([]byte(`{"amountSat":1000,"paymentHash":"abc","serialized":"lnbc1..."}`))
+	})
+
+	_, err := CreateInvoice(CreateInvoiceRequest{
+		DescriptionHash: "deadbeef",
+		AmountSat:       "1000",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetIncomingPayment_Success(t *testing.T) {
+	withTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/payments/incoming/myhash" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Write([]byte(`{"paymentHash":"myhash","isPaid":true,"receivedSat":500,"fees":2}`))
+	})
+
+	p, err := GetIncomingPayment("myhash")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !p.IsPaid || p.ReceivedSat != 500 || p.Fees != 2 {
+		t.Fatalf("unexpected payment: %+v", p)
+	}
+}
+
+func TestGetNodeInfo_Success(t *testing.T) {
+	withTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/getinfo" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Write([]byte(`{"nodeId":"node123","version":"0.8.0","channels":[{"state":"Normal","balanceSat":1000}]}`))
+	})
+
+	info, err := GetNodeInfo()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.NodeID != "node123" || info.Version != "0.8.0" {
+		t.Fatalf("unexpected node info: %+v", info)
+	}
+	if len(info.Channels) != 1 || info.Channels[0].BalanceSat != 1000 {
+		t.Fatalf("unexpected channels: %+v", info.Channels)
+	}
+}
+
+func TestGetOffer_Success(t *testing.T) {
+	withTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/getoffer" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Write([]byte("lno1offerstring"))
+	})
+
+	offer, err := GetOffer()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if offer != "lno1offerstring" {
+		t.Fatalf("unexpected offer: %q", offer)
+	}
+}
+
+func TestListChannels_NormalChannel(t *testing.T) {
+	body := `[{
+		"type":"fr.acinq.lightning.channel.states.Normal",
+		"commitments":{
+			"channelParams":{"channelId":"chan1"},
+			"active":[{"localCommit":{"spec":{"toLocal":3000,"toRemote":7000}}}]
+		}
+	}]`
+	withTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/listchannels" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Write([]byte(body))
+	})
+
+	channels, err := ListChannels()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(channels) != 1 {
+		t.Fatalf("expected 1 channel, got %d", len(channels))
+	}
+	ch := channels[0]
+	if ch.State != "Normal" || ch.ChannelID != "chan1" {
+		t.Fatalf("unexpected channel: %+v", ch)
+	}
+	if ch.BalanceMsat != 3000 || ch.InboundLiquidMsat != 7000 {
+		t.Fatalf("unexpected balances: %+v", ch)
+	}
+}
+
+func TestListChannels_SkipsChannelWithoutCommitments(t *testing.T) {
+	body := `[{"type":"fr.acinq.lightning.channel.states.WaitForFundingConfirmed"}]`
+	withTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(body))
+	})
+
+	channels, err := ListChannels()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(channels) != 0 {
+		t.Fatalf("expected channel without commitments to be skipped, got %d", len(channels))
+	}
+}
+
+func TestExtractChannel_OfflineUnwrapsNestedState(t *testing.T) {
+	// Offline/Syncing channels nest their commitments inside "state".
+	raw := listChannelRaw{
+		Type:  "fr.acinq.lightning.channel.states.Offline",
+		State: []byte(`{"type":"fr.acinq.lightning.channel.states.Normal","commitments":{"channelParams":{"channelId":"nested1"},"active":[{"localCommit":{"spec":{"toLocal":42,"toRemote":58}}}]}}`),
+	}
+	ch, ok := extractChannel(raw)
+	if !ok {
+		t.Fatal("expected ok for offline channel with nested commitments")
+	}
+	if ch.State != "Normal" {
+		t.Fatalf("expected inner state Normal, got %q", ch.State)
+	}
+	if ch.ChannelID != "nested1" || ch.BalanceMsat != 42 || ch.InboundLiquidMsat != 58 {
+		t.Fatalf("unexpected channel: %+v", ch)
+	}
+}
+
+func TestSendLightningPayment_Success(t *testing.T) {
+	withTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/payinvoice" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse form: %v", err)
+		}
+		if r.PostForm.Get("invoice") != "lnbc1..." || r.PostForm.Get("amountSat") != "250" {
+			t.Errorf("unexpected form: %v", r.PostForm)
+		}
+		w.Write([]byte(`{"recipientAmountSat":250,"routingFeeSat":1,"paymentId":"pid","paymentHash":"ph","paymentPreimage":"pre"}`))
+	})
+
+	resp, reason, err := SendLightningPayment(SendLightningPaymentRequest{
+		AmountSat: "250",
+		Invoice:   "lnbc1...",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reason != "no_error" {
+		t.Fatalf("expected reason no_error, got %q", reason)
+	}
+	if resp.RecipientAmountSat != 250 || resp.RoutingFeeSat != 1 || resp.PaymentPreimage != "pre" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestSendLightningPayment_FailStatusCode(t *testing.T) {
+	withTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("rejected"))
+	})
+
+	_, reason, err := SendLightningPayment(SendLightningPaymentRequest{
+		AmountSat: "250",
+		Invoice:   "lnbc1...",
+	})
+	if err == nil {
+		t.Fatal("expected error on non-200 status")
+	}
+	if reason != "fail_status_code" {
+		t.Fatalf("expected reason fail_status_code, got %q", reason)
+	}
+}
+
+func TestSendLightningPayment_DecodeError(t *testing.T) {
+	withTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json"))
+	})
+
+	_, reason, err := SendLightningPayment(SendLightningPaymentRequest{
+		AmountSat: "250",
+		Invoice:   "lnbc1...",
+	})
+	if err == nil {
+		t.Fatal("expected error decoding invalid JSON")
+	}
+	if reason != "failed_decode_response" {
+		t.Fatalf("expected reason failed_decode_response, got %q", reason)
+	}
+}
+
+func TestListIncomingPayments_Success(t *testing.T) {
+	withTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/payments/incoming" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("limit") != "5" || q.Get("offset") != "10" || q.Get("all") != "true" {
+			t.Errorf("unexpected query params: %v", q)
+		}
+		w.Write([]byte(`[{"paymentHash":"h1","isPaid":true,"receivedSat":100},{"paymentHash":"h2","isPaid":false}]`))
+	})
+
+	payments, err := ListIncomingPayments(5, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(payments) != 2 {
+		t.Fatalf("expected 2 payments, got %d", len(payments))
+	}
+	if payments[0].PaymentHash != "h1" || payments[0].ReceivedSat != 100 {
+		t.Fatalf("unexpected first payment: %+v", payments[0])
+	}
+}
+
+func TestListOutgoingPayments_Success(t *testing.T) {
+	withTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/payments/outgoing" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Write([]byte(`[{"paymentId":"p1","isPaid":true,"sent":250,"fees":1}]`))
+	})
+
+	payments, err := ListOutgoingPayments(5, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(payments) != 1 || payments[0].PaymentID != "p1" || payments[0].Sent != 250 {
+		t.Fatalf("unexpected payments: %+v", payments)
+	}
+}
+
+func TestGetOutgoingPayment_Success(t *testing.T) {
+	withTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/payments/outgoing/pid1" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Write([]byte(`{"paymentHash":"ph","isPaid":true,"sent":250,"fees":3}`))
+	})
+
+	p, err := GetOutgoingPayment("pid1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !p.IsPaid || p.SentSat != 250 || p.FeesSat != 3 {
+		t.Fatalf("unexpected payment: %+v", p)
+	}
+}
+
+func TestSendLightningPayment_NoConfig(t *testing.T) {
+	primePassword("")
+	defer primePassword("testpass")
+
+	_, reason, err := SendLightningPayment(SendLightningPaymentRequest{
+		AmountSat: "250",
+		Invoice:   "lnbc1...",
+	})
+	if err == nil {
+		t.Fatal("expected error when password unavailable")
+	}
+	if reason != "no_config" {
+		t.Fatalf("expected reason no_config, got %q", reason)
+	}
+}

--- a/docker/card/util/utils_test.go
+++ b/docker/card/util/utils_test.go
@@ -1,0 +1,114 @@
+package util
+
+import (
+	"encoding/base64"
+	"errors"
+	"testing"
+)
+
+func TestConvertPaymentHash_ValidHex(t *testing.T) {
+	got := ConvertPaymentHash("00ff10")
+	want := []int{0, 255, 16}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d ints, got %d (%v)", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("at index %d expected %d, got %d", i, want[i], got[i])
+		}
+	}
+}
+
+func TestConvertPaymentHash_Empty(t *testing.T) {
+	got := ConvertPaymentHash("")
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %v", got)
+	}
+}
+
+func TestConvertPaymentHash_InvalidHex(t *testing.T) {
+	got := ConvertPaymentHash("zzzz")
+	if got != nil {
+		t.Fatalf("expected nil for invalid hex, got %v", got)
+	}
+}
+
+func TestConvertPaymentHash_OddLength(t *testing.T) {
+	// odd-length strings are not valid hex
+	got := ConvertPaymentHash("abc")
+	if got != nil {
+		t.Fatalf("expected nil for odd-length hex, got %v", got)
+	}
+}
+
+func TestRandomHex_LengthAndHex(t *testing.T) {
+	h := Random_hex()
+	// 16 random bytes -> 32 hex characters
+	if len(h) != 32 {
+		t.Fatalf("expected 32 hex chars, got %d (%q)", len(h), h)
+	}
+	for _, c := range h {
+		isHex := (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')
+		if !isHex {
+			t.Fatalf("non-hex character %q in %q", c, h)
+		}
+	}
+}
+
+func TestRandomHex_Unique(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		h := Random_hex()
+		if seen[h] {
+			t.Fatalf("duplicate Random_hex value: %q", h)
+		}
+		seen[h] = true
+	}
+}
+
+func TestQrPngBase64Encode_ProducesPng(t *testing.T) {
+	encoded := QrPngBase64Encode("lnurl1test")
+	if encoded == "" {
+		t.Fatal("expected non-empty base64 output")
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("output is not valid base64: %v", err)
+	}
+
+	// PNG files start with the 8-byte signature 89 50 4E 47 0D 0A 1A 0A
+	pngHeader := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	if len(raw) < len(pngHeader) {
+		t.Fatalf("decoded output too short to be a PNG (%d bytes)", len(raw))
+	}
+	for i, b := range pngHeader {
+		if raw[i] != b {
+			t.Fatalf("decoded output is not a PNG (byte %d = 0x%02X, want 0x%02X)", i, raw[i], b)
+		}
+	}
+}
+
+func TestCheckAndLog_NilDoesNotPanic(t *testing.T) {
+	// Should be a no-op and must not panic.
+	CheckAndLog(nil)
+	CheckAndLog(errors.New("logged error"))
+}
+
+func TestCheckAndPanic_NilDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("CheckAndPanic(nil) panicked: %v", r)
+		}
+	}()
+	CheckAndPanic(nil)
+}
+
+func TestCheckAndPanic_NonNilPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("CheckAndPanic(err) did not panic")
+		}
+	}()
+	CheckAndPanic(errors.New("boom"))
+}


### PR DESCRIPTION
## Summary

Following a test-coverage audit, this PR fills the largest gaps — the previously **untested** packages, which notably included the entire **payment-execution path** (`phoenix/`) and all CLI admin commands.

### Coverage changes

| Package | Before | After |
|---|---|---|
| `phoenix/` | **0%** | **81.9%** |
| `util/` | **0%** | **87.5%** |
| `card` (CLI) | **0%** | **55.1%** |
| `db/` | 55.9% | **69.2%** |

### What's added

- **`phoenix/`** — One small production change: `phoenixBaseURL` is now a `var` (not a `const`) so tests can point it at an `httptest.Server`. New tests cover every endpoint (balance, create-invoice with description vs. description-hash, incoming/outgoing payments, list channels + `extractChannel` nested-offline unwrapping, node info, offer) plus `SendLightningPayment`'s reason codes (`no_error`, `fail_status_code`, `failed_decode_response`, `no_config`), basic-auth header, and non-200 handling.
- **`util/`** — `ConvertPaymentHash` (valid/invalid/odd-length hex), `Random_hex` (length + uniqueness), `QrPngBase64Encode` (verifies PNG signature), `CheckAndLog`/`CheckAndPanic`.
- **`db/`** — Previously-uncovered functions: `Db_select_all_cards`, `Db_select_all_settings`, `Db_select_card_payments`, `Db_select_card_receipts` (limit + all), `Db_get_total_card_balance`, `Db_get_table_counts`, `Db_get_card_note_by_invoice`, `Db_get_card_lnurlw_enable`, `Db_update_card_with_pin` / `_without_pin`, `Db_update_receipt_paid`.
- **`card` (CLI)** — `setupCardAmountForTag`, `clearCardBalancesForTag`, `getBalance`, `programBatch`, `wipeCard`, and `processArgs` dispatch, including arg-validation/error branches.

### Notes / follow-ups not in this PR

The audit also flagged the Docker self-update mechanism (`web/update.go`), the websocket hub (`web/ws_hub.go`, `web/websocket.go`), and the external-API admin endpoints (`admin_api_about/database/transactions`) as 0%. Those need a bit more scaffolding (fake Docker socket / websocket clients) and are left for a follow-up.

### Verification

- `go test -race -count=1 ./...` — all packages pass
- `go vet ./...` — clean

https://claude.ai/code/session_01SGypnFVgtT5RfqJ64yB7ne

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGypnFVgtT5RfqJ64yB7ne)_