### PR TITLE
chore: ignore node_modules in launcher

### DIFF
--- a/launcher/.gitignore
+++ b/launcher/.gitignore
@@ -1,1 +1,2 @@
 .vercel
+node_modules/


### PR DESCRIPTION
The launcher's \`.gitignore\` only ignored \`.vercel\`, so npm-installed dependencies (414 files) were showing up as untracked in the working tree. Add \`node_modules/\` to keep \`git status\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)