### PR TITLE
chore: ignore local docs/plans directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 docker/card/card
 notes
 .github/prompts/*
+# local planning docs
+docs/plans/


### PR DESCRIPTION
Local planning notes under \`docs/plans/\` were showing up as untracked. Add \`docs/plans/\` to the root \`.gitignore\` to keep \`git status\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)