### PR TITLE
Auto-reconnect Phoenix websocket listener; gate card on phoenix health

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,15 @@ services:
       resources:
         limits:
           memory: 384M
+    # phoenix-cli reads the http-password from /phoenix/.phoenix/phoenix.conf and
+    # calls the local HTTP API — a success means phoenixd is up and answering.
+    # Lets `card` wait for service_healthy instead of racing the port at boot.
+    healthcheck:
+      test: ["CMD", "/phoenix/phoenix-cli", "getinfo"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
     volumes:
       - phoenix_data:/phoenix/.phoenix
     networks:
@@ -28,8 +37,10 @@ services:
         limits:
           memory: 192M
     depends_on:
-      - phoenix
-      - webproxy
+      phoenix:
+        condition: service_healthy
+      webproxy:
+        condition: service_started
     healthcheck:
       test: ["CMD", "curl", "-fsS", "--head", "http://localhost:8000/"]
       interval: 30s

--- a/docker/card/web/app.go
+++ b/docker/card/web/app.go
@@ -11,10 +11,11 @@ type App struct {
 	db_read  *sql.DB // read-only pool (many concurrent connections)
 	db_write *sql.DB // single-connection writer (serialised via SetMaxOpenConns(1))
 	hub      *wsHub
+	stop     chan struct{} // closed to signal background goroutines (e.g. Phoenix listener) to exit
 }
 
 func NewApp(db_read, db_write *sql.DB) *App {
-	app := &App{db_read: db_read, db_write: db_write, hub: newWsHub()}
+	app := &App{db_read: db_read, db_write: db_write, hub: newWsHub(), stop: make(chan struct{})}
 	app.startPhoenixListener()
 	app.startChannelPoller()
 	app.startReceiptPoller()

--- a/docker/card/web/web_test.go
+++ b/docker/card/web/web_test.go
@@ -36,7 +36,9 @@ func openTestDB(t *testing.T) *sql.DB {
 func openTestApp(t *testing.T) *App {
 	t.Helper()
 	db_conn := openTestDB(t)
-	return NewApp(db_conn, db_conn) // same DB for both read and write in tests
+	app := NewApp(db_conn, db_conn) // same DB for both read and write in tests
+	t.Cleanup(func() { close(app.stop) })
+	return app
 }
 
 // Test getBearerToken with valid Bearer token

--- a/docker/card/web/websocket.go
+++ b/docker/card/web/websocket.go
@@ -33,71 +33,143 @@ type WebSocketMessage struct {
 	PayerKey    string `json:"payerKey,omitempty"`
 }
 
-// startPhoenixListener opens a single websocket to Phoenix and broadcasts
+const phoenixMaxBackoff = 30 * time.Second
+
+// phoenixBackoff returns how long to wait before the next reconnect attempt,
+// given the number of consecutive failures (0 means the last attempt
+// succeeded). It grows exponentially (1s, 2s, 4s, …) capped at
+// phoenixMaxBackoff so a flapping Phoenix never produces a hot reconnect loop.
+func phoenixBackoff(failures int) time.Duration {
+	if failures <= 0 {
+		return 0
+	}
+	if failures > 6 { // 1<<6 == 64s already exceeds the cap; also guards against shift overflow
+		return phoenixMaxBackoff
+	}
+	d := time.Duration(1<<(failures-1)) * time.Second
+	if d > phoenixMaxBackoff {
+		return phoenixMaxBackoff
+	}
+	return d
+}
+
+// interruptibleSleep waits for d, returning early if stop is closed so shutdown
+// is not blocked by a pending backoff delay.
+func interruptibleSleep(d time.Duration, stop <-chan struct{}) {
+	if d <= 0 {
+		return
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-stop:
+	case <-t.C:
+	}
+}
+
+// reconnectLoop calls connect, which is expected to block while the connection
+// is alive and return when it fails to establish or drops. After each return
+// it waits backoff(consecutiveFailures) before reconnecting; a successful
+// connection (connect returns nil) resets the failure count. The loop exits
+// when stop is closed.
+func reconnectLoop(stop <-chan struct{}, connect func() error, backoff func(int) time.Duration) {
+	failures := 0
+	for {
+		select {
+		case <-stop:
+			return
+		default:
+		}
+
+		if err := connect(); err != nil {
+			failures++
+		} else {
+			failures = 0
+		}
+
+		select {
+		case <-stop:
+			return
+		default:
+		}
+		interruptibleSleep(backoff(failures), stop)
+	}
+}
+
+// startPhoenixListener keeps a websocket open to Phoenix and broadcasts
 // incoming payment events to all connected admin clients via the hub.
-// It runs once and reconnects are not needed (Phoenix connection is long-lived).
+// It reconnects automatically: Phoenix may not be ready when the card service
+// boots (a cold-start race) and may restart later, so a single dial is not
+// enough — connectAndServePhoenix is retried with exponential backoff until
+// app.stop is closed.
 func (app *App) startPhoenixListener() {
+	go reconnectLoop(app.stop, app.connectAndServePhoenix, phoenixBackoff)
+}
+
+// connectAndServePhoenix loads the Phoenix config, dials its websocket and
+// blocks reading payment events until the connection fails to establish or
+// drops, returning the error that ended it (nil on a clean close). It never
+// retries itself — reconnectLoop owns the backoff and reconnection.
+func (app *App) connectAndServePhoenix() error {
 	cfg, err := ini.Load("/root/.phoenix/phoenix.conf")
 	if err != nil {
-		log.Error("failed to load phoenix config: ", err)
-		return
+		log.Info("phoenix config not available, will retry: ", err.Error())
+		return err
 	}
 
 	hp := cfg.Section("").Key("http-password").String()
-	h := http.Header{"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte(":" + hp))}}
+	h := http.Header{"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte(":"+hp))}}
 	c, _, err := websocket.DefaultDialer.Dial("ws://phoenix:9740/websocket", h)
 	if err != nil {
-		log.Info("phoenix websocket not available: ", err.Error())
-		return
+		log.Info("phoenix websocket not available, will retry: ", err.Error())
+		return err
 	}
 
 	log.Info("phoenix websocket listener connected")
+	defer c.Close()
 
-	go func() {
-		defer c.Close()
-		for {
-			_, message, err := c.ReadMessage()
-			if err != nil {
-				log.Info("websocket to phoenix is closing: ", err.Error())
-				return
-			}
-
-			log.Info("phoenix ws message: ", string(message))
-
-			var wsMsg WebSocketMessage
-			err = json.Unmarshal(message, &wsMsg)
-			if err != nil {
-				log.Error("websocket json unmarshal error: ", err)
-				continue
-			}
-
-			incomingPayment, err := phoenix.GetIncomingPayment(wsMsg.PaymentHash)
-			if err != nil {
-				log.Error("phoenix GetIncomingPayment error: ", err)
-				continue
-			}
-
-			// Mark any matching receipt as paid (for lightning address payments)
-			if incomingPayment.IsPaid {
-				db.Db_set_receipt_paid(app.db_write, incomingPayment.PaymentHash, "websocket")
-			}
-
-			event := wsPaymentEvent{
-				Type:        "payment_received",
-				AmountSat:   incomingPayment.ReceivedSat,
-				PaymentHash: incomingPayment.PaymentHash,
-				Timestamp:   incomingPayment.CompletedAt / 1000,
-			}
-
-			eventJSON, err := json.Marshal(event)
-			if err != nil {
-				log.Error("websocket json marshal error: ", err)
-				continue
-			}
-
-			app.hub.broadcast(eventJSON)
+	for {
+		_, message, err := c.ReadMessage()
+		if err != nil {
+			log.Info("phoenix websocket closed, will reconnect: ", err.Error())
+			return err
 		}
-	}()
+
+		log.Info("phoenix ws message: ", string(message))
+
+		var wsMsg WebSocketMessage
+		err = json.Unmarshal(message, &wsMsg)
+		if err != nil {
+			log.Error("websocket json unmarshal error: ", err)
+			continue
+		}
+
+		incomingPayment, err := phoenix.GetIncomingPayment(wsMsg.PaymentHash)
+		if err != nil {
+			log.Error("phoenix GetIncomingPayment error: ", err)
+			continue
+		}
+
+		// Mark any matching receipt as paid (for lightning address payments)
+		if incomingPayment.IsPaid {
+			db.Db_set_receipt_paid(app.db_write, incomingPayment.PaymentHash, "websocket")
+		}
+
+		event := wsPaymentEvent{
+			Type:        "payment_received",
+			AmountSat:   incomingPayment.ReceivedSat,
+			PaymentHash: incomingPayment.PaymentHash,
+			Timestamp:   incomingPayment.CompletedAt / 1000,
+		}
+
+		eventJSON, err := json.Marshal(event)
+		if err != nil {
+			log.Error("websocket json marshal error: ", err)
+			continue
+		}
+
+		app.hub.broadcast(eventJSON)
+	}
 }
 
 // startChannelPoller polls Phoenix channel status every 30s and broadcasts

--- a/docker/card/web/websocket_reconnect_test.go
+++ b/docker/card/web/websocket_reconnect_test.go
@@ -1,0 +1,122 @@
+package web
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestPhoenixBackoff(t *testing.T) {
+	cases := []struct {
+		failures int
+		want     time.Duration
+	}{
+		{0, 0},
+		{1, 1 * time.Second},
+		{2, 2 * time.Second},
+		{3, 4 * time.Second},
+		{4, 8 * time.Second},
+		{5, 16 * time.Second},
+		{6, 30 * time.Second},   // 32s capped to 30s
+		{7, 30 * time.Second},   // capped
+		{100, 30 * time.Second}, // capped, no overflow
+	}
+	for _, c := range cases {
+		if got := phoenixBackoff(c.failures); got != c.want {
+			t.Errorf("phoenixBackoff(%d) = %v, want %v", c.failures, got, c.want)
+		}
+	}
+}
+
+// The old listener gave up after a single failed dial. The loop must keep
+// retrying instead, with the failure count growing each time it fails.
+func TestReconnectLoop_RetriesAfterFailure(t *testing.T) {
+	stop := make(chan struct{})
+	attempts := 0
+	connect := func() error {
+		attempts++
+		if attempts >= 3 {
+			close(stop)
+		}
+		return errors.New("connection refused")
+	}
+	var backoffCalls []int
+	backoff := func(failures int) time.Duration {
+		backoffCalls = append(backoffCalls, failures)
+		return 0
+	}
+
+	reconnectLoop(stop, connect, backoff)
+
+	if attempts != 3 {
+		t.Fatalf("expected 3 connect attempts, got %d", attempts)
+	}
+	want := []int{1, 2} // 3rd attempt closes stop before its backoff
+	if len(backoffCalls) != len(want) {
+		t.Fatalf("backoff called %v, want %v", backoffCalls, want)
+	}
+	for i := range want {
+		if backoffCalls[i] != want[i] {
+			t.Fatalf("backoff calls = %v, want %v", backoffCalls, want)
+		}
+	}
+}
+
+// A successful connection (connect returns nil) that later drops must reset
+// the consecutive-failure count so backoff starts over.
+func TestReconnectLoop_ResetsFailureCountAfterSuccess(t *testing.T) {
+	stop := make(chan struct{})
+	results := []error{errors.New("e"), errors.New("e"), nil, errors.New("e")}
+	i := 0
+	connect := func() error {
+		r := results[i]
+		i++
+		if i >= len(results) {
+			close(stop)
+		}
+		return r
+	}
+	var backoffCalls []int
+	backoff := func(failures int) time.Duration {
+		backoffCalls = append(backoffCalls, failures)
+		return 0
+	}
+
+	reconnectLoop(stop, connect, backoff)
+
+	want := []int{1, 2, 0} // fail, fail, success(reset); 4th attempt stops before backoff
+	if len(backoffCalls) != len(want) {
+		t.Fatalf("backoff called %v, want %v", backoffCalls, want)
+	}
+	for i := range want {
+		if backoffCalls[i] != want[i] {
+			t.Fatalf("backoff calls = %v, want %v", backoffCalls, want)
+		}
+	}
+}
+
+func TestReconnectLoop_StopsWhenStopClosed(t *testing.T) {
+	stop := make(chan struct{})
+	close(stop)
+	called := false
+	connect := func() error { called = true; return nil }
+	reconnectLoop(stop, connect, func(int) time.Duration { return 0 })
+	if called {
+		t.Fatal("connect should not be called when stop is already closed")
+	}
+}
+
+func TestInterruptibleSleep_ReturnsWhenStopped(t *testing.T) {
+	stop := make(chan struct{})
+	close(stop)
+	done := make(chan struct{})
+	go func() {
+		interruptibleSleep(time.Hour, stop)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("interruptibleSleep did not return promptly when stop was closed")
+	}
+}


### PR DESCRIPTION
## Problem

The Phoenix payment-event listener (`startPhoenixListener`) dialed the websocket **exactly once** at startup and gave up on any error. This was caught in real logs:

```
INFO phoenix websocket not available: dial tcp 172.18.0.4:9740: connect: connection refused
WARN channel poll error: ListChannels request failed: ... connection refused
```

A cold-boot race (card up before phoenixd's `:9740` is accepting connections) or any later phoenixd restart left the realtime payment listener **permanently dead** until the card service itself restarted. Only the 30s receipt poller covered incoming payments in the meantime — so the "Live" admin experience silently degraded with no recovery.

## Fix

**1. Reconnect loop** (`docker/card/web/websocket.go`)
- `connectAndServePhoenix() error` dials + serves, returning the error that ended the connection (config-load / dial / read failure).
- `reconnectLoop()` retries with exponential backoff (`phoenixBackoff`: 1s→30s cap, resets on a successful connect) and exits when `app.stop` closes.
- `interruptibleSleep()` keeps the backoff wait abortable for clean shutdown.
- `App` gains a `stop chan struct{}`; `openTestApp` closes it so the loop doesn't retry forever during the suite.

**2. Compose healthcheck** (`docker-compose.yml`) — complements the loop by closing the *startup* race cleanly:
- `phoenix` gets `healthcheck: ["CMD", "/phoenix/phoenix-cli", "getinfo"]` (auto-reads `http-password` from the in-container config).
- `card.depends_on` switched to the map form gating on `phoenix: condition: service_healthy`.

The loop is the robust fix (covers restarts); the healthcheck only covers boot ordering.

## Tests

New unit tests in `docker/card/web/websocket_reconnect_test.go`: backoff schedule, retry-on-failure, failure-count reset after success, already-stopped case, interruptible-sleep.

## Verification

- `go vet ./...`, `go build ./...`, `go test -race -count=1 ./...` → all `ok` (exit 0).
- Booted the stack: `phoenix Waiting → Healthy → card Starting`, and card logged `phoenix websocket listener connected` with **no** `connection refused` / `channel poll error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)