### PR TITLE
Document version-bump convention, bump to 0.19.4, simplify launcher TLS probe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,10 @@ GitHub Actions workflow (`.github/workflows/ci.yml`) runs on push/PR to `main`:
 
 Uses Go 1.25.11 with CGo enabled for sqlite3, Node 22 for frontend. Docker Hub push requires GitHub secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`.
 
+## Versioning
+
+**Bump the version for every PR.** Patch-bump `Version` in `docker/card/build/build.go` (e.g. `0.19.3` → `0.19.4`) as part of each PR. On merge to `main`, CI republishes `boltcard/card:latest` with `org.opencontainers.image.version` set to this string; the About-page update check only surfaces the "Update available" button on deployed hubs when that label exceeds their running version. A PR that changes the image without bumping the version therefore ships an update no one can see.
+
 ## CLI Commands (run inside card container)
 
 ```bash
@@ -88,7 +92,7 @@ Entry point: `main.go` → opens SQLite DB → runs CLI or starts HTTP server on
 - `phoenix/` — HTTP client for Phoenix Server API (invoices, payments, balance, channels). Uses basic auth from phoenix config (password cached at startup with `sync.Once`)
 - `crypto/` — AES-CMAC authentication and AES decryption for Bolt Card NFC protocol
 - `util/` — Error handling helpers (`CheckAndLog`), random hex generation, QR code encoding
-- `build/` — Version string (currently "0.17.1"), date/time injected at build
+- `build/` — Version string (currently "0.19.3"), date/time injected at build
 - `web-content/` — Static assets under `public/`, SPA build output under `admin/spa/`
 
 ### Route Groups (`web/app.go`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Entry point: `main.go` → opens SQLite DB → runs CLI or starts HTTP server on
 - `phoenix/` — HTTP client for Phoenix Server API (invoices, payments, balance, channels). Uses basic auth from phoenix config (password cached at startup with `sync.Once`)
 - `crypto/` — AES-CMAC authentication and AES decryption for Bolt Card NFC protocol
 - `util/` — Error handling helpers (`CheckAndLog`), random hex generation, QR code encoding
-- `build/` — Version string (currently "0.19.3"), date/time injected at build
+- `build/` — Version string (currently "0.19.4"), date/time injected at build
 - `web-content/` — Static assets under `public/`, SPA build output under `admin/spa/`
 
 ### Route Groups (`web/app.go`)

--- a/docker/card/build/build.go
+++ b/docker/card/build/build.go
@@ -1,5 +1,5 @@
 package build
 
-var Version string = "0.19.3"
+var Version string = "0.19.4"
 var Date string
 var Time string

--- a/launcher/api/status.js
+++ b/launcher/api/status.js
@@ -36,38 +36,36 @@ function parseLogStep(line) {
   return 2;
 }
 
-// Probe with strict TLS (valid cert = fully ready)
-function probeStrict(hostname) {
+// TLS handshake completed but the certificate isn't trusted yet — i.e. Caddy
+// is up and serving on 443 but the Let's Encrypt cert hasn't been issued.
+// (vs. ECONNREFUSED/ETIMEDOUT/etc. which mean services aren't up at all)
+const TLS_CERT_ERRORS = new Set([
+  'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+  'SELF_SIGNED_CERT_IN_CHAIN',
+  'DEPTH_ZERO_SELF_SIGNED_CERT',
+  'CERT_HAS_EXPIRED',
+  'CERT_NOT_YET_VALID',
+  'ERR_TLS_CERT_ALTNAME_INVALID',
+  'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+]);
+
+// Probe HTTPS with cert validation left ON (the default). A trusted cert means
+// the hub is fully ready; a cert-validation error means services are up but the
+// cert is still pending; anything else means services aren't responding yet.
+function probe(hostname) {
   return new Promise((resolve) => {
     const req = https.request({
       hostname,
       path: '/',
       method: 'HEAD',
       timeout: 5000,
-      rejectUnauthorized: true,
     }, () => {
       resolve('ready');
     });
     req.on('timeout', () => { req.destroy(); resolve(null); });
-    req.on('error', () => resolve(null));
-    req.end();
-  });
-}
-
-// Probe with relaxed TLS (any response = services running, cert may be pending)
-function probeRelaxed(hostname) {
-  return new Promise((resolve) => {
-    const req = https.request({
-      hostname,
-      path: '/',
-      method: 'HEAD',
-      timeout: 5000,
-      rejectUnauthorized: false,
-    }, () => {
-      resolve('tls_pending');
+    req.on('error', (err) => {
+      resolve(TLS_CERT_ERRORS.has(err.code) ? 'tls_pending' : null);
     });
-    req.on('timeout', () => { req.destroy(); resolve(null); });
-    req.on('error', () => resolve(null));
     req.end();
   });
 }
@@ -114,12 +112,11 @@ module.exports = async function handler(req, res) {
   }
 
   // 3. Check HTTPS for TLS status (always try — port 8080 may be unreachable mid-install)
-  const strict = await probeStrict(hostname);
-  if (strict) {
+  const tls = await probe(hostname);
+  if (tls === 'ready') {
     return res.status(200).json({ step: 6, logLine });
   }
-  const relaxed = await probeRelaxed(hostname);
-  if (relaxed) {
+  if (tls === 'tls_pending') {
     return res.status(200).json({ step: 5, logLine });
   }
 


### PR DESCRIPTION
## What

Three small follow-ups on top of the merged Phoenix-listener-reconnect work (PR #22):

1. **Document the per-PR version-bump convention** in `CLAUDE.md` — adds a *Versioning* section explaining that every PR must patch-bump `docker/card/build/build.go`, because the OCI `org.opencontainers.image.version` label drives the About-page update check. A PR that changes the image without bumping ships an update no deployed hub can see.
2. **Bump version `0.19.3 → 0.19.4`** per that convention (0.19.3 was taken by the esbuild PR #23), and sync the CLAUDE.md "currently" version reference.
3. **Simplify the launcher TLS probe** (`launcher/api/status.js`) — collapse the two-request `probeStrict`/`probeRelaxed` pair into a single `probe()` that keeps cert validation on:
   - trusted cert → `ready` (step 6)
   - TLS cert-validation error (tracked in a new `TLS_CERT_ERRORS` set) → `tls_pending` (step 5, cert still issuing)
   - any other error → not up yet

   Halves the HTTPS requests per status poll and removes the `rejectUnauthorized: false` path.

## Notes

- Rebased onto current `main`, so it sits cleanly on top of the esbuild override (PR #23). The original `0.19.3` bump commit was auto-deduped during rebase (identical patch already upstream); replaced with the `0.19.4` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)