### PR TITLE
Gate Docker Hub push on passing tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
 
   docker:
     runs-on: ubuntu-latest
+    needs: [build, frontend]
     steps:
       - uses: actions/checkout@v4
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Entry point: `main.go` → opens SQLite DB → runs CLI or starts HTTP server on
 - `phoenix/` — HTTP client for Phoenix Server API (invoices, payments, balance, channels). Uses basic auth from phoenix config (password cached at startup with `sync.Once`)
 - `crypto/` — AES-CMAC authentication and AES decryption for Bolt Card NFC protocol
 - `util/` — Error handling helpers (`CheckAndLog`), random hex generation, QR code encoding
-- `build/` — Version string (currently "0.19.5"), date/time injected at build
+- `build/` — Version string (currently "0.19.6"), date/time injected at build
 - `web-content/` — Static assets under `public/`, SPA build output under `admin/spa/`
 
 ### Route Groups (`web/app.go`)

--- a/docker/card/build/build.go
+++ b/docker/card/build/build.go
@@ -1,5 +1,5 @@
 package build
 
-var Version string = "0.19.5"
+var Version string = "0.19.6"
 var Date string
 var Time string


### PR DESCRIPTION
## Summary

The `docker` job in CI had no `needs:` dependency, so it built and pushed `boltcard/card:latest` (and `webproxy`) **in parallel** with the `build` and `frontend` jobs. The push steps are gated only on `github.event_name == 'push' && github.ref == 'refs/heads/main'` — i.e. branch/event, **not** test results. A merge to `main` with failing Go tests or a broken frontend build would still republish `:latest` to Docker Hub.

This adds `needs: [build, frontend]` to the `docker` job so the image build + push only run after `vet`/`build`/`test`/`govulncheck` and the frontend build succeed.

## Changes

- `.github/workflows/ci.yml` — add `needs: [build, frontend]` to the `docker` job.
- Version bump `0.19.5` → `0.19.6` (`build/build.go`, synced reference in `CLAUDE.md`).

## Tradeoff

The three jobs no longer run fully in parallel — `docker` now waits for the slowest of `build`/`frontend`. On PRs that just delays the image-compile check; on `main` it means the push waits for green. That's the intended cost.

The existing push guard (`push` + `refs/heads/main`) is unchanged; the new gate stacks on top, so push now requires **on main AND tests green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)