### PR TITLE
Make LNURLw k1 timeout configurable via setting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,8 @@ The `settings` table stores key-value config. Active settings used by the app:
 - `new_card_code` — secret for card programming endpoint
 - `invite_secret` — optional secret for wallet API card creation
 - `bolt_card_hub_api`, `bolt_card_pos_api` — feature flags ("enabled" to activate)
+- `lnurlw_k1_timeout_seconds` — optional validity window (seconds) for the LNURLw `k1` token in `lnurlw_request.go` (defaults to 10 if unset or invalid)
+- `pay_link_expiry_days` — optional expiry (days) for generated LUD-19 pay links (defaults to 30 if unset or invalid)
 - `schema_version_number` — tracks database migration state
 
 Withdraw limits (`min_withdraw_sats=1`, `max_withdraw_sats=100000000`) are hardcoded in `lnurlw_request.go` and `lnurlw_callback.go`, not stored in the database.

--- a/docker/card/web/lnurlw_request.go
+++ b/docker/card/web/lnurlw_request.go
@@ -68,7 +68,13 @@ func (app *App) CreateHandler_LnurlwRequest() http.HandlerFunc {
 
 		// create and store lnurlw_k1
 		lnurlwK1 := util.Random_hex()
-		lnurlwK1Expiry := time.Now().Unix() + 10 // TODO: get timeout setting
+		k1TimeoutSecs := 10 // default
+		if v := db.Db_get_setting(app.db_read, "lnurlw_k1_timeout_seconds"); v != "" {
+			if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+				k1TimeoutSecs = secs
+			}
+		}
+		lnurlwK1Expiry := time.Now().Unix() + int64(k1TimeoutSecs)
 		db.Db_set_lnurlw_k1(app.db_write, cardId, lnurlwK1, lnurlwK1Expiry)
 
 		// prepare response


### PR DESCRIPTION
## Summary

Implements the `// TODO: get timeout setting` left at `docker/card/web/lnurlw_request.go:71`.

The LNURLw `k1` token validity window was hardcoded to 10 seconds. This change reads an optional `lnurlw_k1_timeout_seconds` setting from the `settings` table, falling back to 10 seconds when the setting is unset or not a positive integer. It mirrors the existing `pay_link_expiry_days` pattern already used a few lines below in the same handler.

The `k1` expiry is consumed in `lnurlw_callback.go`, which rejects callbacks where `now > lnurlwK1Expiry` — so operators on slow NFC/phone setups can now extend the window without a rebuild.

## Changes

- `docker/card/web/lnurlw_request.go` — read `lnurlw_k1_timeout_seconds` (default 10) instead of the hardcoded value.
- `CLAUDE.md` — document the new setting (and the previously undocumented `pay_link_expiry_days`) under the settings list.

## Testing

- `go build ./...` — passes
- `go vet ./web/` — passes
- `go test ./web/` — passes

https://claude.ai/code/session_01XTKnTZdhDx7xJuHn8tHwyj

---
_Generated by [Claude Code](https://claude.ai/code/session_01XTKnTZdhDx7xJuHn8tHwyj)_