### PR TITLE
Add "Allocate funds to card" to admin interface

### DIFF
--- a/docker/card/admin-ui/src/pages/card-detail.tsx
+++ b/docker/card/admin-ui/src/pages/card-detail.tsx
@@ -36,7 +36,16 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { ArrowLeft, Pencil, Check, X, Trash2, Copy, Zap } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { ArrowLeft, Pencil, Check, X, Trash2, Copy, Zap, Plus } from "lucide-react";
 
 interface CardDetail {
   cardId: number;
@@ -116,6 +125,32 @@ export function CardDetailPage() {
     },
     onError: (err) => toast.error(err.message),
   });
+
+  // Allocate funds
+  const [allocateOpen, setAllocateOpen] = useState(false);
+  const [allocateAmount, setAllocateAmount] = useState("");
+
+  const allocateMutation = useMutation({
+    mutationFn: (amountSats: number) =>
+      apiPost(`/cards/${id}/allocate`, { amountSats }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["card", id] });
+      queryClient.invalidateQueries({ queryKey: ["card-txs", id] });
+      setAllocateOpen(false);
+      setAllocateAmount("");
+      toast.success("Funds allocated");
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  function submitAllocate() {
+    const amount = Number(allocateAmount);
+    if (!Number.isInteger(amount) || amount <= 0) {
+      toast.error("Enter a whole number of sats greater than 0");
+      return;
+    }
+    allocateMutation.mutate(amount);
+  }
 
   // Wipe
   const wipeMutation = useMutation({
@@ -238,8 +273,54 @@ export function CardDetailPage() {
 
         {/* Balance card */}
         <Card>
-          <CardHeader>
+          <CardHeader className="flex flex-row items-center justify-between">
             <CardTitle className="text-lg">Balance</CardTitle>
+            <Dialog open={allocateOpen} onOpenChange={setAllocateOpen}>
+              <DialogTrigger asChild>
+                <Button variant="outline" size="sm" disabled={card.wiped === "Y"}>
+                  <Plus className="mr-1 h-4 w-4" />
+                  Allocate
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Allocate funds to card #{card.cardId}</DialogTitle>
+                  <DialogDescription>
+                    Credit this card with a balance top-up. This records a paid
+                    receipt and increases the spendable balance immediately.
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-2">
+                  <Label htmlFor="allocate-amount">Amount (sats)</Label>
+                  <Input
+                    id="allocate-amount"
+                    type="number"
+                    min={1}
+                    step={1}
+                    value={allocateAmount}
+                    onChange={(e) => setAllocateAmount(e.target.value)}
+                    autoFocus
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") submitAllocate();
+                    }}
+                  />
+                </div>
+                <DialogFooter>
+                  <Button
+                    variant="outline"
+                    onClick={() => setAllocateOpen(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    onClick={submitAllocate}
+                    disabled={allocateMutation.isPending}
+                  >
+                    Allocate
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
           </CardHeader>
           <CardContent>
             <p className="text-3xl font-bold font-mono tabular-nums">

--- a/docker/card/admin-ui/src/pages/card-detail.tsx
+++ b/docker/card/admin-ui/src/pages/card-detail.tsx
@@ -70,6 +70,7 @@ interface CardTx {
   timestamp: number;
   amountSats: number;
   feeSats: number;
+  allocated: boolean;
 }
 
 export function CardDetailPage() {
@@ -549,7 +550,11 @@ export function CardDetailPage() {
                       <TableRow key={i}>
                         <TableCell>
                           <Badge variant="secondary">
-                            {isReceipt ? "Received \u2193" : "Sent \u2191"}
+                            {!isReceipt
+                              ? "Sent \u2191"
+                              : tx.allocated
+                                ? "Allocated \u2193"
+                                : "Received \u2193"}
                           </Badge>
                         </TableCell>
                         <TableCell className="text-sm">

--- a/docker/card/build/build.go
+++ b/docker/card/build/build.go
@@ -1,5 +1,5 @@
 package build
 
-var Version string = "0.19.5"
+var Version string = "0.19.6"
 var Date string
 var Time string

--- a/docker/card/db/db_select.go
+++ b/docker/card/db/db_select.go
@@ -153,6 +153,7 @@ type CardTx struct {
 	Timestamp  int
 	AmountSats int
 	FeeSats    int
+	Allocated  bool
 }
 
 type CardTxs []CardTx
@@ -161,11 +162,13 @@ func Db_select_card_txs(db_conn *sql.DB, card_id int) (result CardTxs) {
 	var cardTxs CardTxs
 
 	// get card txs
-	sqlStatement := `SELECT card_receipt_id, 0, timestamp, amount_sats, fee_sats` +
+	// receipts with an empty ln_invoice are manual admin allocations
+	// (no real Lightning invoice behind them); flag them as allocated
+	sqlStatement := `SELECT card_receipt_id, 0, timestamp, amount_sats, fee_sats, (ln_invoice = '')` +
 		` FROM card_receipts` +
 		` WHERE card_receipts.card_id = $1 AND card_receipts.paid_flag='Y'` +
 		` UNION` +
-		` SELECT 0, card_payment_id, timestamp, -amount_sats, -fee_sats` +
+		` SELECT 0, card_payment_id, timestamp, -amount_sats, -fee_sats, 0` +
 		` FROM card_payments` +
 		` WHERE card_payments.card_id = $1 AND card_payments.paid_flag='Y'` +
 		` ORDER BY timestamp DESC;`
@@ -184,7 +187,8 @@ func Db_select_card_txs(db_conn *sql.DB, card_id int) (result CardTxs) {
 			&cardTx.PaymentId,
 			&cardTx.Timestamp,
 			&cardTx.AmountSats,
-			&cardTx.FeeSats)
+			&cardTx.FeeSats,
+			&cardTx.Allocated)
 		if err != nil {
 			log.Error("db_select_card_txs scan error: ", err)
 			continue

--- a/docker/card/web/admin_api_cards.go
+++ b/docker/card/web/admin_api_cards.go
@@ -239,11 +239,12 @@ func (app *App) adminApiCardTxs(w http.ResponseWriter, _ *http.Request, cardId i
 	txs := db.Db_select_card_txs(app.db_read, cardId)
 
 	type txJSON struct {
-		ReceiptId  int `json:"receiptId"`
-		PaymentId  int `json:"paymentId"`
-		Timestamp  int `json:"timestamp"`
-		AmountSats int `json:"amountSats"`
-		FeeSats    int `json:"feeSats"`
+		ReceiptId  int  `json:"receiptId"`
+		PaymentId  int  `json:"paymentId"`
+		Timestamp  int  `json:"timestamp"`
+		AmountSats int  `json:"amountSats"`
+		FeeSats    int  `json:"feeSats"`
+		Allocated  bool `json:"allocated"`
 	}
 
 	result := make([]txJSON, 0, len(txs))
@@ -254,6 +255,7 @@ func (app *App) adminApiCardTxs(w http.ResponseWriter, _ *http.Request, cardId i
 			Timestamp:  tx.Timestamp,
 			AmountSats: tx.AmountSats,
 			FeeSats:    tx.FeeSats,
+			Allocated:  tx.Allocated,
 		})
 	}
 

--- a/docker/card/web/admin_api_cards.go
+++ b/docker/card/web/admin_api_cards.go
@@ -71,6 +71,8 @@ func (app *App) adminApiCardRouter(w http.ResponseWriter, r *http.Request) {
 		app.adminApiUpdateCardNote(w, r, cardId)
 	case action == "limits" && r.Method == "PUT":
 		app.adminApiUpdateCardLimits(w, r, cardId)
+	case action == "allocate" && r.Method == "POST":
+		app.adminApiAllocateFunds(w, r, cardId)
 	case action == "wipe" && r.Method == "POST":
 		app.adminApiWipeCard(w, r, cardId)
 	case action == "txs" && r.Method == "GET":
@@ -173,6 +175,52 @@ func (app *App) adminApiUpdateCardLimits(w http.ResponseWriter, r *http.Request,
 	}
 
 	writeJSON(w, map[string]bool{"ok": true})
+}
+
+// adminApiAllocateFunds credits a card with a manual balance top-up. It records
+// a paid card_receipt (mirroring the SetupCardAmountForTag CLI command) so the
+// allocation shows up in the card's transaction history and balance.
+func (app *App) adminApiAllocateFunds(w http.ResponseWriter, r *http.Request, cardId int) {
+	var req struct {
+		AmountSats int `json:"amountSats"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	// card_receipts has a CHECK (amount_sats > 0) constraint
+	if req.AmountSats <= 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "amountSats must be greater than 0"})
+		return
+	}
+
+	// Db_get_card filters wiped='N', so this also rejects wiped/unknown cards
+	if _, err := db.Db_get_card(app.db_read, cardId); err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		writeJSON(w, map[string]string{"error": "card not found"})
+		return
+	}
+
+	// a unique r_hash_hex is required (UNIQUE constraint); use a random value
+	// since there is no real Lightning invoice behind a manual allocation
+	receiptId := db.Db_add_card_receipt(app.db_write, cardId, "", util.Random_hex(), req.AmountSats)
+	if receiptId == 0 {
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(w, map[string]string{"error": "failed to allocate funds"})
+		return
+	}
+	db.Db_update_receipt_paid(app.db_write, receiptId)
+
+	balance := db.Db_get_card_balance(app.db_read, cardId)
+
+	log.Info("admin allocated funds: card=", cardId, " amount=", req.AmountSats)
+	writeJSON(w, map[string]any{
+		"ok":          true,
+		"balanceSats": balance,
+	})
 }
 
 func (app *App) adminApiWipeCard(w http.ResponseWriter, _ *http.Request, cardId int) {

--- a/docker/card/web/admin_api_test.go
+++ b/docker/card/web/admin_api_test.go
@@ -533,6 +533,110 @@ func TestAdminApiUpdateCardLimits_InvalidEnable(t *testing.T) {
 	}
 }
 
+func TestAdminApiAllocateFunds(t *testing.T) {
+	app := openTestApp(t)
+	token := setupAdminSession(t, app)
+	cardId := insertFundedCard(t, app.db_write, 10000)
+
+	handler := app.CreateHandler_AdminApi()
+	body := `{"amountSats":25000}`
+	r := httptest.NewRequest("POST", "/admin/api/cards/"+strconv.Itoa(cardId)+"/allocate",
+		strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	r.AddCookie(&http.Cookie{Name: "admin_session_token", Value: token})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Ok          bool `json:"ok"`
+		BalanceSats int  `json:"balanceSats"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Ok {
+		t.Fatal("expected ok=true")
+	}
+	if resp.BalanceSats != 35000 {
+		t.Fatalf("expected balance 35000, got %d", resp.BalanceSats)
+	}
+
+	// Verify the balance persisted in the database
+	if balance := db.Db_get_card_balance(app.db_read, cardId); balance != 35000 {
+		t.Fatalf("expected db balance 35000, got %d", balance)
+	}
+}
+
+func TestAdminApiAllocateFunds_InvalidAmount(t *testing.T) {
+	app := openTestApp(t)
+	token := setupAdminSession(t, app)
+	cardId := insertFundedCard(t, app.db_write, 10000)
+
+	handler := app.CreateHandler_AdminApi()
+	for _, body := range []string{`{"amountSats":0}`, `{"amountSats":-100}`} {
+		r := httptest.NewRequest("POST", "/admin/api/cards/"+strconv.Itoa(cardId)+"/allocate",
+			strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+		r.AddCookie(&http.Cookie{Name: "admin_session_token", Value: token})
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("body %s: expected 400, got %d", body, w.Code)
+		}
+	}
+
+	// balance must be unchanged
+	if balance := db.Db_get_card_balance(app.db_read, cardId); balance != 10000 {
+		t.Fatalf("expected balance 10000, got %d", balance)
+	}
+}
+
+func TestAdminApiAllocateFunds_NotFound(t *testing.T) {
+	app := openTestApp(t)
+	token := setupAdminSession(t, app)
+
+	handler := app.CreateHandler_AdminApi()
+	r := httptest.NewRequest("POST", "/admin/api/cards/99999/allocate",
+		strings.NewReader(`{"amountSats":1000}`))
+	r.Header.Set("Content-Type", "application/json")
+	r.AddCookie(&http.Cookie{Name: "admin_session_token", Value: token})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestAdminApiAllocateFunds_Repeatable(t *testing.T) {
+	app := openTestApp(t)
+	token := setupAdminSession(t, app)
+	cardId := insertFundedCard(t, app.db_write, 0)
+
+	handler := app.CreateHandler_AdminApi()
+	// Allocate twice — each must succeed despite the r_hash_hex UNIQUE constraint
+	for i := 0; i < 2; i++ {
+		r := httptest.NewRequest("POST", "/admin/api/cards/"+strconv.Itoa(cardId)+"/allocate",
+			strings.NewReader(`{"amountSats":5000}`))
+		r.Header.Set("Content-Type", "application/json")
+		r.AddCookie(&http.Cookie{Name: "admin_session_token", Value: token})
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("allocation %d: expected 200, got %d: %s", i, w.Code, w.Body.String())
+		}
+	}
+
+	if balance := db.Db_get_card_balance(app.db_read, cardId); balance != 10000 {
+		t.Fatalf("expected balance 10000 after two allocations, got %d", balance)
+	}
+}
+
 func TestAdminApiWipeCard(t *testing.T) {
 	app := openTestApp(t)
 	token := setupAdminSession(t, app)

--- a/docker/card/web/admin_api_test.go
+++ b/docker/card/web/admin_api_test.go
@@ -692,6 +692,57 @@ func TestAdminApiCardTxs(t *testing.T) {
 	}
 }
 
+func TestAdminApiCardTxs_AllocatedFlag(t *testing.T) {
+	app := openTestApp(t)
+	token := setupAdminSession(t, app)
+	// insertFundedCard records a real receipt (non-empty ln_invoice)
+	cardId := insertFundedCard(t, app.db_write, 50000)
+
+	// manual allocation records a receipt with empty ln_invoice
+	r := httptest.NewRequest("POST", "/admin/api/cards/"+strconv.Itoa(cardId)+"/allocate",
+		strings.NewReader(`{"amountSats":1234}`))
+	r.Header.Set("Content-Type", "application/json")
+	r.AddCookie(&http.Cookie{Name: "admin_session_token", Value: token})
+	app.CreateHandler_AdminApi().ServeHTTP(httptest.NewRecorder(), r)
+
+	handler := app.CreateHandler_AdminApi()
+	req := httptest.NewRequest("GET", "/admin/api/cards/"+strconv.Itoa(cardId)+"/txs", nil)
+	req.AddCookie(&http.Cookie{Name: "admin_session_token", Value: token})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Txs []struct {
+			AmountSats int  `json:"amountSats"`
+			Allocated  bool `json:"allocated"`
+		} `json:"txs"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Txs) != 2 {
+		t.Fatalf("expected 2 txs, got %d", len(resp.Txs))
+	}
+	for _, tx := range resp.Txs {
+		switch tx.AmountSats {
+		case 1234:
+			if !tx.Allocated {
+				t.Fatal("expected manual allocation to be flagged allocated=true")
+			}
+		case 50000:
+			if tx.Allocated {
+				t.Fatal("expected real Lightning receipt to be allocated=false")
+			}
+		default:
+			t.Fatalf("unexpected tx amount %d", tx.AmountSats)
+		}
+	}
+}
+
 func TestAdminApiAbout(t *testing.T) {
 	app := openTestApp(t)
 	token := setupAdminSession(t, app)


### PR DESCRIPTION
## Summary

Adds an "Allocate funds to card" feature to the admin interface, so an admin can manually credit a card's balance from the card detail page (previously only possible via the `SetupCardAmountForTag` CLI command, which is one-shot per card).

## Changes

**Backend** (`web/admin_api_cards.go`)
- New `POST /admin/api/cards/{id}/allocate` endpoint (behind `adminApiAuth`).
- Records a paid `card_receipt` — the same mechanism `SetupCardAmountForTag` uses — so the allocation appears in transaction history and increases the spendable balance immediately.
- Uses a random `r_hash_hex` (via `util.Random_hex()`) instead of the card id, so allocation is **repeatable** (the `r_hash_hex` UNIQUE constraint would otherwise block a second top-up).
- Validates `amountSats > 0` (satisfies the `card_receipts` `CHECK (amount_sats > 0)` constraint) and rejects wiped/unknown cards (`Db_get_card` filters `wiped='N'`). Returns the new `balanceSats`.

**Frontend** (`admin-ui/src/pages/card-detail.tsx`)
- "Allocate" button on the Balance card opens a dialog to enter an amount in sats.
- On success, invalidates the card and tx queries so balance and history refresh; the button is disabled for wiped cards.

**Other**
- Added tests: success, invalid amount (0/negative), not-found, and repeatable allocation.
- Bumped version `0.19.5` → `0.19.6`.

## Testing
- `go vet ./web/ ./db/` — clean
- `go test -race -count=1 ./web/ ./db/ ./crypto/` — all pass
- `npm run build` (admin-ui) — succeeds

https://claude.ai/code/session_018Gp5j6PpSDFqpBhV14RGBe

---
_Generated by [Claude Code](https://claude.ai/code/session_018Gp5j6PpSDFqpBhV14RGBe)_