### PR TITLE
Reframe card programming UI around single-card default

### DIFF
--- a/docker/card/admin-ui/src/components/batch-program-dialog.tsx
+++ b/docker/card/admin-ui/src/components/batch-program-dialog.tsx
@@ -12,7 +12,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { Copy, Check, Plus } from "lucide-react";
+import { Copy, Check, Plus, ChevronDown } from "lucide-react";
 
 interface BatchResult {
   ok: boolean;
@@ -21,15 +21,20 @@ interface BatchResult {
   qr: string;
 }
 
+const DEFAULTS = {
+  groupTag: "",
+  maxCards: "1",
+  initialBalance: "0",
+  expiryHours: "24",
+};
+
 export function BatchProgramDialog() {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
-  const [form, setForm] = useState({
-    groupTag: "",
-    maxCards: "10",
-    initialBalance: "0",
-    expiryHours: "24",
-  });
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [form, setForm] = useState(DEFAULTS);
+
+  const multiple = (Number(form.maxCards) || 0) > 1;
 
   const mutation = useMutation({
     mutationFn: (data: {
@@ -63,7 +68,8 @@ export function BatchProgramDialog() {
     if (!next) {
       mutation.reset();
       setCopied(false);
-      setForm({ groupTag: "", maxCards: "10", initialBalance: "0", expiryHours: "24" });
+      setShowAdvanced(false);
+      setForm(DEFAULTS);
     }
   }
 
@@ -72,16 +78,17 @@ export function BatchProgramDialog() {
       <DialogTrigger asChild>
         <Button size="sm">
           <Plus className="mr-2 h-4 w-4" />
-          Batch Program
+          Add Card
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-md overflow-hidden">
         <DialogHeader>
-          <DialogTitle>Batch Program Cards</DialogTitle>
+          <DialogTitle>{multiple ? "Program Cards" : "Program a Card"}</DialogTitle>
           <DialogDescription>
-            Create a programming link for multiple NFC cards.
+            Creates a programming link.
             <br />
-            Scan the QR code with the Bolt Card app.
+            Scan the QR code with the Bolt Card app to program{" "}
+            {multiple ? "each card" : "your card"}.
           </DialogDescription>
         </DialogHeader>
 
@@ -91,11 +98,16 @@ export function BatchProgramDialog() {
               <div className="rounded-lg bg-white p-4">
                 <img
                   src={`data:image/png;base64,${mutation.data.qr}`}
-                  alt="Batch Program QR"
+                  alt="Program Card QR"
                   className="w-full max-w-64"
                 />
               </div>
             </div>
+            {multiple && (
+              <p className="text-center text-sm text-muted-foreground">
+                Scan this same link once per card &mdash; up to {form.maxCards} cards.
+              </p>
+            )}
             <Button variant="outline" className="w-full" onClick={copyLink}>
               {copied ? (
                 <Check className="mr-2 h-4 w-4 text-[var(--success)]" />
@@ -107,21 +119,9 @@ export function BatchProgramDialog() {
           </div>
         ) : (
           <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="groupTag">Group Tag</Label>
-              <Input
-                id="groupTag"
-                value={form.groupTag}
-                onChange={(e) =>
-                  setForm({ ...form, groupTag: e.target.value })
-                }
-                placeholder="e.g. meetup-jan"
-                required
-              />
-            </div>
-            <div className="grid grid-cols-3 gap-3">
+            <div className="grid grid-cols-2 gap-3">
               <div className="space-y-2">
-                <Label htmlFor="maxCards">Max Cards</Label>
+                <Label htmlFor="maxCards">Number of cards</Label>
                 <Input
                   id="maxCards"
                   type="number"
@@ -145,27 +145,66 @@ export function BatchProgramDialog() {
                   }
                 />
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="expiryHours">Expiry (hrs)</Label>
-                <Input
-                  id="expiryHours"
-                  type="number"
-                  min="1"
-                  value={form.expiryHours}
-                  onChange={(e) =>
-                    setForm({ ...form, expiryHours: e.target.value })
-                  }
-                  required
-                />
-              </div>
             </div>
+            {multiple && (
+              <p className="text-xs text-muted-foreground">
+                One link programs up to this many cards. Leave at 1 for a single card.
+              </p>
+            )}
+
+            <button
+              type="button"
+              onClick={() => setShowAdvanced((v) => !v)}
+              className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+            >
+              <ChevronDown
+                className={`h-4 w-4 transition-transform ${
+                  showAdvanced ? "rotate-180" : ""
+                }`}
+              />
+              Advanced
+            </button>
+
+            {showAdvanced && (
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <Label htmlFor="groupTag">Group (optional)</Label>
+                  <Input
+                    id="groupTag"
+                    value={form.groupTag}
+                    onChange={(e) =>
+                      setForm({ ...form, groupTag: e.target.value })
+                    }
+                    placeholder="e.g. meetup-jan"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="expiryHours">Link expiry (hrs)</Label>
+                  <Input
+                    id="expiryHours"
+                    type="number"
+                    min="1"
+                    value={form.expiryHours}
+                    onChange={(e) =>
+                      setForm({ ...form, expiryHours: e.target.value })
+                    }
+                    required
+                  />
+                </div>
+              </div>
+            )}
+
             {mutation.error && (
               <p className="text-sm text-destructive">
                 {mutation.error.message}
               </p>
             )}
             <Button type="submit" className="w-full" disabled={mutation.isPending}>
-              {mutation.isPending ? "Creating..." : "Create Batch"}
+              {mutation.isPending
+                ? "Creating..."
+                : multiple
+                  ? "Create Link"
+                  : "Create Card Link"}
             </Button>
           </form>
         )}

--- a/docker/card/build/build.go
+++ b/docker/card/build/build.go
@@ -1,5 +1,5 @@
 package build
 
-var Version string = "0.19.5"
+var Version string = "0.19.6"
 var Date string
 var Time string

--- a/docker/card/web/admin_api_cards.go
+++ b/docker/card/web/admin_api_cards.go
@@ -227,9 +227,9 @@ func (app *App) adminApiBatchCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.GroupTag == "" || req.MaxCards <= 0 || req.ExpiryHours <= 0 {
+	if req.MaxCards <= 0 || req.ExpiryHours <= 0 {
 		w.WriteHeader(http.StatusBadRequest)
-		writeJSON(w, map[string]string{"error": "groupTag, maxCards, and expiryHours are required"})
+		writeJSON(w, map[string]string{"error": "maxCards and expiryHours are required"})
 		return
 	}
 


### PR DESCRIPTION
## Why

User feedback: *"only wanted one card, and the bulk card thing was a little confusing."*

The only way to program a card was a **"Batch Program"** button opening a **"Batch Program Cards"** dialog. Everything signalled bulk: a required **Group Tag**, a **Max Cards** field defaulting to **10**, and a **"Create Batch"** button. A single card was fully supported by the backend but never presented as the normal case.

## Changes

**Frontend** (`batch-program-dialog.tsx`)
- Trigger button renamed **"Batch Program" → "Add Card"**.
- Dialog title is **"Program a Card"** by default, switching to **"Program Cards"** only when the count is > 1.
- **"Max Cards" → "Number of cards"**, now defaulting to **1** (was 10). Helper text about reusing the link appears only when programming multiple.
- **Group Tag** is now optional and tucked, with link expiry, behind an **"Advanced"** disclosure — so the common path is just *number of cards + balance*.
- Submit button copy adapts to single vs. multiple.

**Backend** (`admin_api_cards.go`)
- Dropped the requirement that `groupTag` be non-empty; only `maxCards` and `expiryHours` are validated now.

**Versioning**
- Bumped `build.go` `0.19.5 → 0.19.6`.

## Notes

Batch/bulk programming is fully preserved — set the count above 1 (and optionally a group tag) and the link can be scanned once per card, exactly as before. This only changes framing and defaults.

## Testing
- `go build ./...`, `go vet ./web/`, `go test ./web/` — pass
- `npm ci && npm run build` (admin-ui) — pass

https://claude.ai/code/session_01WSA2GXHoNmEpR8vHfxCr4x

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSA2GXHoNmEpR8vHfxCr4x)_