### PR TITLE
test: cover double-spend guard and unblock Phoenix-calling handler tests

### DIFF
--- a/docker/card/build/build.go
+++ b/docker/card/build/build.go
@@ -1,5 +1,5 @@
 package build
 
-var Version string = "0.19.5"
+var Version string = "0.19.6"
 var Date string
 var Time string

--- a/docker/card/db/db_tx_test.go
+++ b/docker/card/db/db_tx_test.go
@@ -1,0 +1,174 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// openConcurrentTestDB opens a file-backed SQLite database that permits
+// multiple concurrent connections. The in-memory ":memory:" DSN used by
+// openTestDB gives each pooled connection its own private database, which
+// makes it useless for testing the cross-connection locking that
+// Db_reserve_card_payment relies on. A temp file with a busy timeout lets
+// contending BEGIN IMMEDIATE transactions queue on the SQLite write lock
+// instead of failing with SQLITE_BUSY.
+func openConcurrentTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	os.Setenv("HOST_DOMAIN", "test.example.com")
+
+	dsn := filepath.Join(t.TempDir(), "cards.db") +
+		"?_journal=WAL&_timeout=5000&_foreign_keys=1"
+
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// fundCard inserts a card and credits it with a single paid receipt,
+// returning the new card's id.
+func fundCard(t *testing.T, db *sql.DB, amountSats int) int {
+	t.Helper()
+	Db_insert_card(db, "k0", "k1", "k2", "k3", "k4", "login", "pass")
+	if err := Db_set_tokens(db, "login", "pass", "tok", "refresh"); err != nil {
+		t.Fatalf("failed to set tokens: %v", err)
+	}
+	cardId := Db_get_card_id_from_access_token(db, "tok")
+	if cardId == 0 {
+		t.Fatal("expected non-zero card_id after insert")
+	}
+	Db_add_card_receipt(db, cardId, "lnbcreceipt", "fundhash", amountSats)
+	Db_set_receipt_paid(db, "fundhash", "test")
+
+	if bal := Db_get_card_balance(db, cardId); bal != amountSats {
+		t.Fatalf("expected funded balance %d, got %d", amountSats, bal)
+	}
+	return cardId
+}
+
+// TestReserveCardPayment_Success verifies the happy path: a reservation
+// against a sufficiently funded card succeeds, returns a payment id, and
+// reduces the card balance by the reserved amount.
+func TestReserveCardPayment_Success(t *testing.T) {
+	db := openConcurrentTestDB(t)
+	Db_init(db)
+
+	cardId := fundCard(t, db, 1000)
+
+	balance, paymentID, err := Db_reserve_card_payment(db, cardId, 1000, 1000, "lnbcpay")
+	if err != nil {
+		t.Fatalf("expected reservation to succeed, got %v", err)
+	}
+	if balance != 1000 {
+		t.Fatalf("expected reported balance 1000, got %d", balance)
+	}
+	if paymentID == 0 {
+		t.Fatal("expected non-zero payment id")
+	}
+	if bal := Db_get_card_balance(db, cardId); bal != 0 {
+		t.Fatalf("expected balance 0 after reservation, got %d", bal)
+	}
+}
+
+// TestReserveCardPayment_InsufficientFunds verifies that a reservation
+// requiring more than the card balance is rejected, no payment row is
+// created, and the balance is unchanged.
+func TestReserveCardPayment_InsufficientFunds(t *testing.T) {
+	db := openConcurrentTestDB(t)
+	Db_init(db)
+
+	cardId := fundCard(t, db, 500)
+
+	balance, paymentID, err := Db_reserve_card_payment(db, cardId, 1000, 1000, "lnbcpay")
+	if !errors.Is(err, ErrInsufficientFunds) {
+		t.Fatalf("expected ErrInsufficientFunds, got %v", err)
+	}
+	if balance != 500 {
+		t.Fatalf("expected reported balance 500, got %d", balance)
+	}
+	if paymentID != 0 {
+		t.Fatalf("expected no payment id on failure, got %d", paymentID)
+	}
+	if bal := Db_get_card_balance(db, cardId); bal != 500 {
+		t.Fatalf("expected balance unchanged at 500, got %d", bal)
+	}
+}
+
+// TestReserveCardPayment_NoDoubleSpend is the core race-condition test for
+// the double-spend guard. A card is funded with exactly enough for one
+// payment, then many goroutines race to reserve that same amount
+// simultaneously. The BEGIN IMMEDIATE transaction in Db_reserve_card_payment
+// must serialise these so that exactly one wins and the rest see
+// ErrInsufficientFunds — never two successful reservations against a single
+// balance.
+func TestReserveCardPayment_NoDoubleSpend(t *testing.T) {
+	db := openConcurrentTestDB(t)
+	Db_init(db)
+
+	const payment = 1000
+	cardId := fundCard(t, db, payment)
+
+	const goroutines = 20
+	var (
+		wg           sync.WaitGroup
+		start        = make(chan struct{})
+		mu           sync.Mutex
+		successes    int
+		insufficient int
+		otherErrs    []error
+	)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start // release all goroutines at once to maximise contention
+			_, _, err := Db_reserve_card_payment(db, cardId, payment, payment, "lnbcpay")
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case err == nil:
+				successes++
+			case errors.Is(err, ErrInsufficientFunds):
+				insufficient++
+			default:
+				otherErrs = append(otherErrs, err)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	if len(otherErrs) > 0 {
+		t.Fatalf("unexpected errors during concurrent reservations: %v", otherErrs)
+	}
+	if successes != 1 {
+		t.Fatalf("expected exactly 1 successful reservation, got %d", successes)
+	}
+	if insufficient != goroutines-1 {
+		t.Fatalf("expected %d insufficient-funds results, got %d", goroutines-1, insufficient)
+	}
+
+	// Exactly one payment row should have been committed and the balance
+	// drained to zero — no double spend.
+	if bal := Db_get_card_balance(db, cardId); bal != 0 {
+		t.Fatalf("expected balance 0 after single reservation, got %d", bal)
+	}
+
+	var rows int
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM card_payments WHERE card_id = ?", cardId,
+	).Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if rows != 1 {
+		t.Fatalf("expected exactly 1 card_payments row, got %d", rows)
+	}
+}

--- a/docker/card/phoenix/phoenix_test.go
+++ b/docker/card/phoenix/phoenix_test.go
@@ -15,16 +15,14 @@ func primePassword(pw string) {
 }
 
 // withTestServer points phoenixBaseURL at a test server for the duration of a
-// test and primes a non-empty password. The previous base URL is restored on
-// cleanup.
+// test and primes a non-empty password. The previous base URL and password
+// are restored on cleanup via the shared UseMockPhoenix hook.
 func withTestServer(t *testing.T, handler http.HandlerFunc) {
 	t.Helper()
-	primePassword("testpass")
 	srv := httptest.NewServer(handler)
-	old := phoenixBaseURL
-	phoenixBaseURL = srv.URL
+	restore := UseMockPhoenix(srv.URL)
 	t.Cleanup(func() {
-		phoenixBaseURL = old
+		restore()
 		srv.Close()
 	})
 }

--- a/docker/card/phoenix/test_hooks.go
+++ b/docker/card/phoenix/test_hooks.go
@@ -1,0 +1,42 @@
+package phoenix
+
+// This file exposes a small amount of test-only surface so that packages
+// outside phoenix (notably web) can exercise handlers that call the Phoenix
+// API against a mock server. The phoenix package's own tests use the private
+// helpers in phoenix_test.go, but those are not visible to other packages,
+// and phoenixBaseURL / the cached password are deliberately unexported.
+//
+// These functions must only be called from tests. They are kept in a normal
+// (non _test.go) file purely so they are importable from other packages'
+// tests; they perform no I/O and have no effect unless explicitly invoked.
+
+// UseMockPhoenix points the Phoenix client at baseURL (typically an
+// httptest.Server URL) and primes a dummy password so that Phoenix-calling
+// code reaches the mock instead of failing at password load. It returns a
+// restore function that reverts both the base URL and the password cache to
+// their previous values.
+//
+// Always defer the returned restore: the password cache and base URL are
+// process-global, so leaving them primed would leak into other tests (for
+// example, code paths that expect an unconfigured Phoenix). Because the
+// underlying state is global, callers must not run such tests in parallel with
+// anything that exercises Phoenix.
+func UseMockPhoenix(baseURL string) (restore func()) {
+	oldURL := phoenixBaseURL
+	oldPassword := cachedPassword
+	oldErr := passwordErr
+
+	// Mark the one-time loader as done so getPassword reads the cache below
+	// rather than trying to open the real phoenix config file.
+	passwordOnce.Do(func() {})
+
+	phoenixBaseURL = baseURL
+	cachedPassword = "testpass"
+	passwordErr = nil
+
+	return func() {
+		phoenixBaseURL = oldURL
+		cachedPassword = oldPassword
+		passwordErr = oldErr
+	}
+}

--- a/docker/card/web/phoenix_handler_test.go
+++ b/docker/card/web/phoenix_handler_test.go
@@ -1,0 +1,150 @@
+package web
+
+import (
+	"card/db"
+	"card/phoenix"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newTestAppNoPollers builds an App backed by an initialised in-memory DB
+// WITHOUT starting the Phoenix background pollers. The pollers call Phoenix on
+// a 30s loop and read the process-global phoenixBaseURL / password cache; tests
+// that mutate those globals (via phoenix.UseMockPhoenix) must avoid spawning
+// pollers of their own so the mutation cannot race a concurrent poll.
+func newTestAppNoPollers(t *testing.T) *App {
+	t.Helper()
+	db_conn, err := sql.Open("sqlite3", ":memory:?_foreign_keys=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db_conn.Close() })
+	db.Db_init(db_conn)
+	return &App{db_read: db_conn, db_write: db_conn, hub: newWsHub(), stop: make(chan struct{})}
+}
+
+// authedCard inserts a card, sets an access token, and returns the token so a
+// handler protected by getAuthenticatedCardID can be exercised.
+func authedCard(t *testing.T, app *App, login, token string) {
+	t.Helper()
+	db.Db_insert_card(app.db_write, "k0", "k1", "k2", "k3", "k4", login, "pass")
+	if err := db.Db_set_tokens(app.db_write, login, "pass", token, token+"refresh"); err != nil {
+		t.Fatalf("failed to set tokens: %v", err)
+	}
+}
+
+// TestAddInvoice_CreatesReceipt exercises the wallet AddInvoice handler end to
+// end against a mock Phoenix server. Before phoenix.UseMockPhoenix existed,
+// this handler could not be tested from the web package because every call hit
+// the real (unreachable) Phoenix node. It verifies that the handler forwards
+// the requested amount to Phoenix, maps the invoice into the response, and
+// records a card_receipt row.
+func TestAddInvoice_CreatesReceipt(t *testing.T) {
+	app := newTestAppNoPollers(t)
+	authedCard(t, app, "invlogin", "invtoken")
+
+	const serialized = "lnbc500n1mockinvoice"
+	const paymentHash = "abcdef0123456789"
+
+	// Mock Phoenix /createinvoice and point the client at it.
+	var gotAmount string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/createinvoice" {
+			t.Errorf("unexpected phoenix path: %s", r.URL.Path)
+		}
+		r.ParseForm()
+		gotAmount = r.FormValue("amountSat")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(phoenix.CreateInvoiceResponse{
+			AmountSat:   50,
+			PaymentHash: paymentHash,
+			Serialized:  serialized,
+		})
+	}))
+	defer srv.Close()
+	defer phoenix.UseMockPhoenix(srv.URL)()
+
+	body := `{"amt":"50","memo":"coffee"}`
+	r := httptest.NewRequest("POST", "/addinvoice", strings.NewReader(body))
+	r.Header.Set("Authorization", "Bearer invtoken")
+	w := httptest.NewRecorder()
+
+	app.CreateHandler_AddInvoice().ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if gotAmount != "50" {
+		t.Fatalf("expected amountSat 50 forwarded to phoenix, got %q", gotAmount)
+	}
+
+	var resp AddInvoiceResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON response: %s", w.Body.String())
+	}
+	if resp.PayReq != serialized || resp.PaymentRequest != serialized {
+		t.Fatalf("expected invoice %q in response, got pay_req=%q payment_request=%q",
+			serialized, resp.PayReq, resp.PaymentRequest)
+	}
+	if resp.Hash != paymentHash {
+		t.Fatalf("expected hash %q, got %q", paymentHash, resp.Hash)
+	}
+
+	// The handler should have recorded a card_receipt for the invoice.
+	var receipts int
+	if err := app.db_read.QueryRow(
+		"SELECT COUNT(*) FROM card_receipts WHERE r_hash_hex = ?", paymentHash,
+	).Scan(&receipts); err != nil {
+		t.Fatal(err)
+	}
+	if receipts != 1 {
+		t.Fatalf("expected 1 card_receipt for the invoice, got %d", receipts)
+	}
+}
+
+// TestAddInvoice_RejectsBadAmount verifies the handler validates the amount
+// before calling Phoenix. A non-positive amount must be rejected with an error.
+func TestAddInvoice_RejectsBadAmount(t *testing.T) {
+	app := newTestAppNoPollers(t)
+	authedCard(t, app, "badamtlogin", "badamttoken")
+
+	body := `{"amt":"0","memo":"x"}`
+	r := httptest.NewRequest("POST", "/addinvoice", strings.NewReader(body))
+	r.Header.Set("Authorization", "Bearer badamttoken")
+	w := httptest.NewRecorder()
+
+	app.CreateHandler_AddInvoice().ServeHTTP(w, r)
+
+	var resp AddInvoiceResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON response: %s", w.Body.String())
+	}
+	if resp.Error == "" {
+		t.Fatal("expected an error for non-positive amount")
+	}
+}
+
+// TestAddInvoice_RequiresAuth verifies the handler rejects unauthenticated
+// requests before touching Phoenix. The wallet API signals failures with an
+// error body rather than an HTTP status code.
+func TestAddInvoice_RequiresAuth(t *testing.T) {
+	app := newTestAppNoPollers(t)
+
+	body := `{"amt":"50","memo":"x"}`
+	r := httptest.NewRequest("POST", "/addinvoice", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	app.CreateHandler_AddInvoice().ServeHTTP(w, r)
+
+	var resp AddInvoiceResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON response: %s", w.Body.String())
+	}
+	if resp.Error == "" {
+		t.Fatal("expected an error for unauthenticated request")
+	}
+}


### PR DESCRIPTION
## Summary

Targets the two highest-value gaps from a test-coverage analysis of the codebase:

1. **The double-spend guard was untested.** `db.Db_reserve_card_payment` — the `BEGIN IMMEDIATE` atomic balance-check-and-reserve whose entire purpose is to prevent double-spend races — had **0% coverage**. The similarly-named existing `TestAtomicBalance` doesn't exercise it (it tests the older non-atomic path and does no concurrency).

2. **Phoenix-calling handlers were untestable from `web`.** `phoenixBaseURL` was package-private, so the `web` package couldn't point the Phoenix client at a mock. Handlers like `CreateHandler_AddInvoice` were stuck near 0% because every call hit the real, unreachable node.

## Changes

- **`db/db_tx_test.go`** — `TestReserveCardPayment_{Success,InsufficientFunds,NoDoubleSpend}`. The no-double-spend test races 20 goroutines at a card funded for exactly one payment and asserts exactly one reservation succeeds, the rest get `ErrInsufficientFunds`, and only one `card_payments` row is committed. Uses a **file-backed** SQLite DB so cross-connection write locking is genuinely exercised (the shared `:memory:` DSN gives each pooled connection its own private database, which can't test the lock).

- **`phoenix/test_hooks.go`** — new exported `UseMockPhoenix(baseURL)` hook (in a non-`_test.go` file so other packages' tests can import it). Points the client at a mock server and primes/restores the cached password via a single returned `restore` closure. `phoenix_test.go`'s `withTestServer` now delegates to it.

- **`web/phoenix_handler_test.go`** — `TestAddInvoice_*` exercise `CreateHandler_AddInvoice` end to end against a mock Phoenix: amount forwarding, invoice mapping, `card_receipt` insertion, bad-amount and unauthenticated rejection. Uses a **poller-free** `App` because the background pollers loop forever calling Phoenix and read the process-global Phoenix state — a poller-started app would race the mock setup. Verified clean under `-race` and `-shuffle`.

## Coverage impact

| Function | Before | After |
|---|---|---|
| `Db_reserve_card_payment` | 0.0% | 77.3% |
| `CreateHandler_AddInvoice` | 2.7% | 81.1% |

Version bumped `0.19.5` → `0.19.6`.

## Test plan
- `go test -race -count=1 ./...` — all pass
- `go test -race -shuffle=on ./web/` — stable across repeated runs (confirms global Phoenix state is restored between tests)
- `go vet ./...` clean

## Notes / follow-ups surfaced during this work
The background pollers (`startChannelPoller`, `startReceiptPoller`) loop on `for {}` and **do not honor `app.stop`**, so they leak past test cleanup and keep calling Phoenix. That's why the new web test deliberately avoids starting pollers. Worth a separate fix.

https://claude.ai/code/session_01BP9dfRzawvCt4KKytwBNsm

---
_Generated by [Claude Code](https://claude.ai/code/session_01BP9dfRzawvCt4KKytwBNsm)_