### PR TITLE
Add admin endpoint to reveal phoenixd recovery phrase

### DIFF
--- a/docker/card/admin-ui/src/pages/phoenix.tsx
+++ b/docker/card/admin-ui/src/pages/phoenix.tsx
@@ -1,10 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
-import { apiFetch } from "@/lib/api";
+import { apiFetch, apiPost } from "@/lib/api";
 import { formatSats, formatTimestamp } from "@/lib/format";
 import { StatCard } from "@/components/stat-card";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   Table,
   TableBody,
@@ -13,8 +16,19 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Zap, Coins, Copy, Check, ArrowDownLeft, ArrowUpRight } from "lucide-react";
-import { useState, useMemo } from "react";
+import {
+  Zap,
+  Coins,
+  Copy,
+  Check,
+  ArrowDownLeft,
+  ArrowUpRight,
+  KeyRound,
+  Eye,
+  EyeOff,
+  ShieldAlert,
+} from "lucide-react";
+import { useState, useMemo, type FormEvent } from "react";
 import { useWebSocketContext } from "@/hooks/use-websocket-context";
 
 interface PhoenixData {
@@ -192,6 +206,8 @@ export function PhoenixPage() {
         </Card>
       )}
 
+      <SeedCard />
+
       {/* Transactions In */}
       <Card>
         <CardHeader>
@@ -286,5 +302,138 @@ export function PhoenixPage() {
         </CardContent>
       </Card>
     </div>
+  );
+}
+
+// SeedCard reveals the phoenixd wallet recovery phrase (BIP39 mnemonic).
+// Hidden by default; revealing requires re-entering the admin password, which
+// the server verifies before returning the words. The words live only in
+// local component state and are cleared when hidden.
+function SeedCard() {
+  const [password, setPassword] = useState("");
+  const [words, setWords] = useState<string[] | null>(null);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [prompting, setPrompting] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  async function handleReveal(e: FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      const res = await apiPost<{ words: string[] }>("/phoenix/seed", {
+        password,
+      });
+      setWords(res.words);
+      setPrompting(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to reveal seed");
+    } finally {
+      setPassword("");
+      setLoading(false);
+    }
+  }
+
+  function hide() {
+    setWords(null);
+    setPrompting(false);
+    setPassword("");
+    setError("");
+    setCopied(false);
+  }
+
+  function copyWords() {
+    if (!words) return;
+    navigator.clipboard.writeText(words.join(" "));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <KeyRound className="h-4 w-4" />
+          Wallet Recovery Phrase
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Alert variant="destructive">
+          <ShieldAlert className="h-4 w-4" />
+          <AlertDescription>
+            These words control the entire Phoenix wallet. Anyone with them can
+            steal all funds. Write them down on paper, store them offline, and
+            never share or photograph them.
+          </AlertDescription>
+        </Alert>
+
+        {words ? (
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+              {words.map((word, i) => (
+                <div
+                  key={i}
+                  className="flex items-center gap-2 rounded border bg-muted px-3 py-2 font-mono text-sm"
+                >
+                  <span className="w-6 text-right tabular-nums text-muted-foreground">
+                    {i + 1}.
+                  </span>
+                  <span>{word}</span>
+                </div>
+              ))}
+            </div>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={copyWords}>
+                {copied ? (
+                  <Check className="mr-2 h-4 w-4 text-success" />
+                ) : (
+                  <Copy className="mr-2 h-4 w-4" />
+                )}
+                Copy
+              </Button>
+              <Button variant="secondary" onClick={hide}>
+                <EyeOff className="mr-2 h-4 w-4" />
+                Hide
+              </Button>
+            </div>
+          </div>
+        ) : prompting ? (
+          <form onSubmit={handleReveal} className="space-y-3">
+            {error && (
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="seed-password">
+                Confirm your admin password to reveal
+              </Label>
+              <Input
+                id="seed-password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                autoFocus
+              />
+            </div>
+            <div className="flex gap-2">
+              <Button type="submit" disabled={loading}>
+                {loading ? "Revealing..." : "Reveal"}
+              </Button>
+              <Button type="button" variant="ghost" onClick={hide}>
+                Cancel
+              </Button>
+            </div>
+          </form>
+        ) : (
+          <Button variant="outline" onClick={() => setPrompting(true)}>
+            <Eye className="mr-2 h-4 w-4" />
+            Reveal recovery phrase
+          </Button>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/docker/card/build/build.go
+++ b/docker/card/build/build.go
@@ -1,5 +1,5 @@
 package build
 
-var Version string = "0.19.5"
+var Version string = "0.19.6"
 var Date string
 var Time string

--- a/docker/card/phoenix/get_seed.go
+++ b/docker/card/phoenix/get_seed.go
@@ -1,0 +1,31 @@
+package phoenix
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// seedFilePath is the location of the phoenixd seed file inside the card
+// container. The phoenix data volume is mounted read-only at /root/.phoenix
+// (see docker-compose.yml), and phoenixd writes the wallet's BIP39 mnemonic
+// here as a single line of space-separated words in plaintext. It is a var
+// (not a const) so tests can point it at a temporary file.
+var seedFilePath = "/root/.phoenix/seed.dat"
+
+// GetSeedWords reads the phoenixd wallet recovery phrase from seed.dat and
+// returns it as a slice of individual words. The file is read fresh on each
+// call (never cached) so the secret does not linger in process memory.
+func GetSeedWords() ([]string, error) {
+	data, err := os.ReadFile(seedFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("read phoenix seed file: %w", err)
+	}
+
+	words := strings.Fields(string(data))
+	if len(words) == 0 {
+		return nil, fmt.Errorf("phoenix seed file is empty")
+	}
+
+	return words, nil
+}

--- a/docker/card/phoenix/get_seed_test.go
+++ b/docker/card/phoenix/get_seed_test.go
@@ -1,0 +1,56 @@
+package phoenix
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetSeedWords(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "seed.dat")
+	// phoenixd writes the mnemonic as space-separated words on a single line.
+	if err := os.WriteFile(path, []byte("abandon ability able about above absent\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := seedFilePath
+	seedFilePath = path
+	defer func() { seedFilePath = orig }()
+
+	words, err := GetSeedWords()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(words) != 6 {
+		t.Fatalf("expected 6 words, got %d: %v", len(words), words)
+	}
+	if words[0] != "abandon" || words[5] != "absent" {
+		t.Fatalf("unexpected words: %v", words)
+	}
+}
+
+func TestGetSeedWords_Missing(t *testing.T) {
+	orig := seedFilePath
+	seedFilePath = filepath.Join(t.TempDir(), "does-not-exist.dat")
+	defer func() { seedFilePath = orig }()
+
+	if _, err := GetSeedWords(); err == nil {
+		t.Fatal("expected error for missing seed file")
+	}
+}
+
+func TestGetSeedWords_Empty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "seed.dat")
+	if err := os.WriteFile(path, []byte("   \n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := seedFilePath
+	seedFilePath = path
+	defer func() { seedFilePath = orig }()
+
+	if _, err := GetSeedWords(); err == nil {
+		t.Fatal("expected error for empty seed file")
+	}
+}

--- a/docker/card/web/admin_api.go
+++ b/docker/card/web/admin_api.go
@@ -47,6 +47,32 @@ func (app *App) adminApiAuth(next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
+// verifyAdminPassword checks a plaintext password against the stored admin
+// hash. A legacy SHA256 hash is migrated to bcrypt on a successful match,
+// mirroring the login flow. Returns false if no admin is registered.
+func (app *App) verifyAdminPassword(password string) bool {
+	adminPasswordHash := db.Db_get_setting(app.db_read, "admin_password_hash")
+	if adminPasswordHash == "" {
+		return false
+	}
+
+	if isBcryptHash(adminPasswordHash) {
+		return CheckPassword(password, adminPasswordHash)
+	}
+
+	// Legacy SHA256 path — check then migrate to bcrypt
+	legacyHash := GetPwHash(app.db_read, password)
+	if subtle.ConstantTimeCompare([]byte(legacyHash), []byte(adminPasswordHash)) == 1 {
+		if newHash, err := HashPassword(password); err == nil {
+			db.Db_set_setting(app.db_write, "admin_password_hash", newHash)
+			db.Db_set_setting(app.db_write, "admin_password_salt", "")
+		}
+		return true
+	}
+
+	return false
+}
+
 // CreateHandler_AdminApi dispatches /admin/api/* requests.
 func (app *App) CreateHandler_AdminApi() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -78,6 +104,9 @@ func (app *App) CreateHandler_AdminApi() http.HandlerFunc {
 
 		case path == "/admin/api/phoenix/transactions":
 			app.adminApiAuth(app.adminApiTransactions)(w, r)
+
+		case path == "/admin/api/phoenix/seed" && r.Method == "POST":
+			app.adminApiAuth(app.adminApiPhoenixSeed)(w, r)
 
 		case path == "/admin/api/cards" && r.Method == "GET":
 			app.adminApiAuth(app.adminApiListCards)(w, r)
@@ -163,24 +192,7 @@ func (app *App) adminApiLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	valid := false
-	if isBcryptHash(adminPasswordHash) {
-		valid = CheckPassword(req.Password, adminPasswordHash)
-	} else {
-		// Legacy SHA256 path — check then migrate to bcrypt
-		legacyHash := GetPwHash(app.db_read, req.Password)
-		if subtle.ConstantTimeCompare([]byte(legacyHash), []byte(adminPasswordHash)) == 1 {
-			valid = true
-			// Migrate to bcrypt
-			newHash, err := HashPassword(req.Password)
-			if err == nil {
-				db.Db_set_setting(app.db_write, "admin_password_hash", newHash)
-				db.Db_set_setting(app.db_write, "admin_password_salt", "")
-			}
-		}
-	}
-
-	if !valid {
+	if !app.verifyAdminPassword(req.Password) {
 		w.WriteHeader(http.StatusUnauthorized)
 		writeJSON(w, map[string]string{"error": "invalid password"})
 		return

--- a/docker/card/web/admin_api_phoenix_seed.go
+++ b/docker/card/web/admin_api_phoenix_seed.go
@@ -1,0 +1,44 @@
+package web
+
+import (
+	"card/phoenix"
+	"encoding/json"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// adminApiPhoenixSeed returns the phoenixd wallet recovery phrase (BIP39
+// mnemonic). This is the highest-value secret in the system — anyone holding
+// it controls the wallet — so beyond the admin session it requires the admin
+// to re-enter their password in the request body. Every attempt is logged for
+// audit. The endpoint is POST-only so the secret is never placed in a URL,
+// and the dispatcher already sets Cache-Control: no-store on the response.
+func (app *App) adminApiPhoenixSeed(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	if !app.verifyAdminPassword(req.Password) {
+		log.Warn("phoenix seed reveal denied: invalid password")
+		w.WriteHeader(http.StatusUnauthorized)
+		writeJSON(w, map[string]string{"error": "invalid password"})
+		return
+	}
+
+	words, err := phoenix.GetSeedWords()
+	if err != nil {
+		log.Warn("phoenix seed reveal failed: ", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(w, map[string]string{"error": "seed not available"})
+		return
+	}
+
+	log.Warn("phoenix seed revealed to authenticated admin")
+	writeJSON(w, map[string]interface{}{"words": words})
+}

--- a/docker/card/web/admin_api_test.go
+++ b/docker/card/web/admin_api_test.go
@@ -316,6 +316,59 @@ func TestAdminApiPhoenix(t *testing.T) {
 	}
 }
 
+func TestAdminApiPhoenixSeed_NoSession(t *testing.T) {
+	app := openTestApp(t)
+	handler := app.CreateHandler_AdminApi()
+
+	r := httptest.NewRequest("POST", "/admin/api/phoenix/seed",
+		strings.NewReader(`{"password":"testpass"}`))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without session, got %d", w.Code)
+	}
+}
+
+func TestAdminApiPhoenixSeed_WrongPassword(t *testing.T) {
+	app := openTestApp(t)
+	token := setupAdminSession(t, app)
+	handler := app.CreateHandler_AdminApi()
+
+	r := httptest.NewRequest("POST", "/admin/api/phoenix/seed",
+		strings.NewReader(`{"password":"wrongpass"}`))
+	r.Header.Set("Content-Type", "application/json")
+	r.AddCookie(&http.Cookie{Name: "admin_session_token", Value: token})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for wrong password, got %d", w.Code)
+	}
+}
+
+func TestAdminApiPhoenixSeed_CorrectPassword(t *testing.T) {
+	app := openTestApp(t)
+	token := setupAdminSession(t, app) // registers password "testpass"
+	handler := app.CreateHandler_AdminApi()
+
+	r := httptest.NewRequest("POST", "/admin/api/phoenix/seed",
+		strings.NewReader(`{"password":"testpass"}`))
+	r.Header.Set("Content-Type", "application/json")
+	r.AddCookie(&http.Cookie{Name: "admin_session_token", Value: token})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	// The password gate passes; the seed file does not exist in the test
+	// environment, so the handler reaches the read step and returns 500.
+	// This confirms a valid password is distinguished from an invalid one.
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 (seed file absent) after valid password, got %d: %s",
+			w.Code, w.Body.String())
+	}
+}
+
 func TestAdminApiSettings(t *testing.T) {
 	app := openTestApp(t)
 	token := setupAdminSession(t, app)


### PR DESCRIPTION
## What

Lets the system admin view the phoenixd wallet's BIP39 recovery phrase (seed words) from the admin UI so it can be backed up offline.

phoenixd writes the seed as space-separated words to `/root/.phoenix/seed.dat`, which is **already** mounted read-only into the card container — so no `docker-compose.yml` changes are needed.

## How it works

**Backend**
- `phoenix.GetSeedWords()` reads and splits `seed.dat` fresh on each call (never cached) so the secret doesn't linger in process memory.
- New endpoint `POST /admin/api/phoenix/seed`, behind the existing admin session, **additionally gated by a re-entered admin password** verified server-side. The seed is the highest-value secret in the system (it controls all funds), so a higher bar than the ambient session cookie is warranted — this protects against an unattended/unlocked browser.
- `POST` keeps the secret out of URLs, browser history, and proxy logs; the API dispatcher already sets `Cache-Control: no-store`.
- Every reveal attempt (success and failure) is logged for audit.
- Extracted a `verifyAdminPassword` helper (including the legacy SHA256→bcrypt migration) and reused it in the login handler to avoid duplicating the auth logic.

**Frontend**
- The Phoenix admin page gains a collapsed **"Wallet Recovery Phrase"** card with a prominent security warning. Revealing requires re-entering the admin password; the words then render in a numbered grid with copy-to-clipboard. "Hide" clears the words from local React state.

## Security considerations
- Double gate: valid admin session **and** password re-prompt.
- Seed never cached server-side; words held only transiently in component state client-side.
- All access attempts logged via `log.Warn`.

## Tests
- `phoenix` package: `GetSeedWords` success / missing-file / empty-file cases (path is now a `var` so tests point at a temp file).
- `web` package: seed endpoint rejects no-session (401), wrong password (401), and confirms a valid password passes the gate.
- Full `go test -race ./...` and frontend `npm run build` pass.

## Versioning
Bumped `0.19.5` → `0.19.6`.

https://claude.ai/code/session_01Wcff45KZpzWhafd7xQ82Wf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wcff45KZpzWhafd7xQ82Wf)_