### PR TITLE
Dedup verifyAdminPassword in withdraw handler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Entry point: `main.go` → opens SQLite DB → runs CLI or starts HTTP server on
 - `phoenix/` — HTTP client for Phoenix Server API (invoices, payments, balance, channels). Uses basic auth from phoenix config (password cached at startup with `sync.Once`)
 - `crypto/` — AES-CMAC authentication and AES decryption for Bolt Card NFC protocol
 - `util/` — Error handling helpers (`CheckAndLog`), random hex generation, QR code encoding
-- `build/` — Version string (currently "0.19.6"), date/time injected at build
+- `build/` — Version string (currently "0.19.7"), date/time injected at build
 - `web-content/` — Static assets under `public/`, SPA build output under `admin/spa/`
 
 ### Route Groups (`web/app.go`)

--- a/docker/card/build/build.go
+++ b/docker/card/build/build.go
@@ -1,5 +1,5 @@
 package build
 
-var Version string = "0.19.6"
+var Version string = "0.19.7"
 var Date string
 var Time string

--- a/docker/card/web/admin_api_withdraw.go
+++ b/docker/card/web/admin_api_withdraw.go
@@ -3,7 +3,6 @@ package web
 import (
 	"card/db"
 	"card/phoenix"
-	"crypto/subtle"
 	"encoding/json"
 	"net/http"
 	"strconv"
@@ -13,19 +12,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// verifyAdminPassword checks a password against the stored admin hash
-// (bcrypt or legacy SHA256). Verification only — it does not migrate.
-func (app *App) verifyAdminPassword(password string) bool {
-	hash := db.Db_get_setting(app.db_read, "admin_password_hash")
-	if hash == "" {
-		return false
-	}
-	if isBcryptHash(hash) {
-		return CheckPassword(password, hash)
-	}
-	legacyHash := GetPwHash(app.db_read, password)
-	return subtle.ConstantTimeCompare([]byte(legacyHash), []byte(hash)) == 1
-}
+// verifyAdminPassword is defined in admin_api.go (it also migrates legacy
+// SHA256 hashes to bcrypt on a successful match); the withdraw handler reuses it.
 
 type withdrawalJSON struct {
 	AmountSats  int    `json:"amountSats"`


### PR DESCRIPTION
## Summary
- Remove the withdraw handler's private copy of `verifyAdminPassword` (and its now-unused `crypto/subtle` import) and reuse the shared method in `admin_api.go`, which additionally migrates legacy SHA256 hashes to bcrypt on a successful match.
- Bump version `0.19.6` → `0.19.7` (`build/build.go` + the CLAUDE.md reference).

## Why
The two implementations were identical except the `admin_api.go` one also performs the legacy-hash migration. Keeping the duplicate in the withdraw handler meant an admin authenticating via the withdraw path never got their SHA256 hash upgraded to bcrypt, and left two copies to keep in sync.

## Testing
- `go vet ./web/` passes.
- Three callers (`admin_api.go`, `admin_api_phoenix_seed.go`, `admin_api_withdraw.go`) now share the single definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)