### PR TITLE
Log successful phoenix seed reveal at INFO, not WARN

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Entry point: `main.go` → opens SQLite DB → runs CLI or starts HTTP server on
 - `phoenix/` — HTTP client for Phoenix Server API (invoices, payments, balance, channels). Uses basic auth from phoenix config (password cached at startup with `sync.Once`)
 - `crypto/` — AES-CMAC authentication and AES decryption for Bolt Card NFC protocol
 - `util/` — Error handling helpers (`CheckAndLog`), random hex generation, QR code encoding
-- `build/` — Version string (currently "0.19.7"), date/time injected at build
+- `build/` — Version string (currently "0.19.8"), date/time injected at build
 - `web-content/` — Static assets under `public/`, SPA build output under `admin/spa/`
 
 ### Route Groups (`web/app.go`)

--- a/docker/card/build/build.go
+++ b/docker/card/build/build.go
@@ -1,5 +1,5 @@
 package build
 
-var Version string = "0.19.7"
+var Version string = "0.19.8"
 var Date string
 var Time string

--- a/docker/card/web/admin_api_phoenix_seed.go
+++ b/docker/card/web/admin_api_phoenix_seed.go
@@ -39,6 +39,6 @@ func (app *App) adminApiPhoenixSeed(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Warn("phoenix seed revealed to authenticated admin")
+	log.Info("phoenix seed revealed to authenticated admin")
 	writeJSON(w, map[string]interface{}{"words": words})
 }


### PR DESCRIPTION
## What

A successful phoenix seed reveal in `adminApiPhoenixSeed` was logged at `WARN`. That line fires only after an authenticated admin has *also* re-entered their password — i.e. the intended, authorized flow. That's a routine audit event, not an anomaly, so it belongs at `INFO`.

The two cases above it stay at `WARN` because they are genuinely noteworthy:
- reveal **denied** — wrong password
- reveal **failed** — seed unavailable / error

## Change

`web/admin_api_phoenix_seed.go`: `log.Warn` → `log.Info` for the success line.

Version bumped 0.19.7 → 0.19.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)