### PR TITLE
Remove Admin Password Reset section from Database page

### DIFF
--- a/docker/card/admin-ui/src/pages/database.tsx
+++ b/docker/card/admin-ui/src/pages/database.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { StatCard } from "@/components/stat-card";
-import { Download, Upload, Copy, Check, KeyRound, Database, HardDrive, Layers } from "lucide-react";
+import { Download, Upload, Database, HardDrive, Layers } from "lucide-react";
 import { useState, type FormEvent } from "react";
 
 interface TableCount {
@@ -25,13 +25,7 @@ function formatBytes(bytes: number): string {
   return (bytes / (1024 * 1024)).toFixed(1) + " MB";
 }
 
-const RESET_COMMANDS = `docker exec -it card bash
-NEW_HASH=$(htpasswd -bnBC 10 "" 'YOUR_NEW_PASSWORD' | tr -d ':\\n' | sed 's/$2y/$2a/')
-sqlite3 /card_data/cards.db "UPDATE settings SET value='$NEW_HASH' WHERE name='admin_password_hash';"
-exit`;
-
 export function DatabasePage() {
-  const [copied, setCopied] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [uploadResult, setUploadResult] = useState<string | null>(null);
 
@@ -41,12 +35,6 @@ export function DatabasePage() {
   });
 
   const totalRows = stats?.tables?.reduce((sum, t) => sum + t.count, 0) ?? 0;
-
-  function copyReset() {
-    navigator.clipboard.writeText(RESET_COMMANDS);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  }
 
   async function handleImport(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -149,29 +137,6 @@ export function DatabasePage() {
               <p className="text-sm text-muted-foreground">{uploadResult}</p>
             )}
           </form>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <CardTitle className="text-lg">
-              <KeyRound className="mr-2 inline h-5 w-5" />
-              Admin Password Reset
-            </CardTitle>
-            <Button variant="outline" size="icon" onClick={copyReset}>
-              {copied ? (
-                <Check className="h-4 w-4 text-[var(--success)]" />
-              ) : (
-                <Copy className="h-4 w-4" />
-              )}
-            </Button>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <pre className="overflow-x-auto rounded-lg bg-muted p-4 text-xs font-mono">
-            {RESET_COMMANDS}
-          </pre>
         </CardContent>
       </Card>
     </div>

--- a/docker/card/build/build.go
+++ b/docker/card/build/build.go
@@ -1,5 +1,5 @@
 package build
 
-var Version string = "0.19.8"
+var Version string = "0.19.9"
 var Date string
 var Time string


### PR DESCRIPTION
## Summary
Removes the "Admin Password Reset" card from the admin Database UI page (`docker/card/admin-ui/src/pages/database.tsx`).

This card displayed a copy-able shell snippet for resetting the admin password via `htpasswd`/`sqlite3` inside the card container.

## Changes
- Removed the Admin Password Reset `<Card>` block from `database.tsx`
- Removed the now-unused `RESET_COMMANDS` constant, `copyReset()` helper, `copied` state, and the `Copy`/`Check`/`KeyRound` icon imports
- Bumped version `0.19.8` → `0.19.9`

## Testing
- `npm run build` in `admin-ui/` passes (tsc + vite build)

https://claude.ai/code/session_013Vi24TTuZtzyYC8wLMTDSb

---
_Generated by [Claude Code](https://claude.ai/code/session_013Vi24TTuZtzyYC8wLMTDSb)_