### PR TITLE
Log missing static files at debug instead of info

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Entry point: `main.go` → opens SQLite DB → runs CLI or starts HTTP server on
 - `phoenix/` — HTTP client for Phoenix Server API (invoices, payments, balance, channels). Uses basic auth from phoenix config (password cached at startup with `sync.Once`)
 - `crypto/` — AES-CMAC authentication and AES decryption for Bolt Card NFC protocol
 - `util/` — Error handling helpers (`CheckAndLog`), random hex generation, QR code encoding
-- `build/` — Version string (currently "0.20.0"), date/time injected at build
+- `build/` — Version string (currently "0.20.1"), date/time injected at build
 - `web-content/` — Static assets under `public/`, SPA build output under `admin/spa/`
 
 ### Route Groups (`web/app.go`)

--- a/docker/card/build/build.go
+++ b/docker/card/build/build.go
@@ -1,5 +1,5 @@
 package build
 
-var Version string = "0.20.0"
+var Version string = "0.20.1"
 var Date string
 var Time string

--- a/docker/card/web/render.go
+++ b/docker/card/web/render.go
@@ -79,7 +79,10 @@ func RenderStaticContent(w http.ResponseWriter, request string) {
 	content, err := os.Open(fullPath)
 
 	if err != nil {
-		log.Info(err.Error())
+		// Missing static files are normal 404s — mostly vulnerability
+		// scanners probing for .env, .git/config, etc. Log at debug so
+		// this background noise doesn't bury operational INFO lines.
+		log.Debug(err.Error())
 		Blank(w, nil)
 		return
 	}


### PR DESCRIPTION
## What

`RenderStaticContent` logged every failed `os.Open` at **INFO** ([render.go:82](docker/card/web/render.go#L82)). These are almost entirely vulnerability scanners probing for `.env`, `.git/config`, `js/sendgrid.js` and similar — normal 404s for files the hub doesn't ship.

Recent live examples:
```
open /web-content/public/.git/config: no such file or directory
open /web-content/public/js/sendgrid.js: no such file or directory
open /web-content/public/.env: no such file or directory
```

## Why

At INFO they bury real operational events (websocket connects, payment flow) and crowd out the About-page log viewer, which only shows the last 20 lines (`/admin/api/about/logs`). They carry no actionable per-line security signal — every public host gets this background radiation, and the probes find nothing because secrets live in the DB / phoenix config, not under `/web-content/public/`.

## Change

Downgrade the missing-file log to `debug`. Still available on demand by setting `log_level` to `debug`; just out of the default INFO stream.

Scope kept surgical — left `suffix not recognised` (fires only *after* a file opens successfully) and `template not found` (internal template logic) at INFO, since neither is 404 probe noise.

Version bumped 0.20.0 → 0.20.1 (PATCH, maintenance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)