### PR TITLE
2FA enrollment UX: submit on Enter + avoid wrong Authy logo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Entry point: `main.go` → opens SQLite DB → runs CLI or starts HTTP server on
 - `phoenix/` — HTTP client for Phoenix Server API (invoices, payments, balance, channels). Uses basic auth from phoenix config (password cached at startup with `sync.Once`)
 - `crypto/` — AES-CMAC authentication and AES decryption for Bolt Card NFC protocol
 - `util/` — Error handling helpers (`CheckAndLog`), random hex generation, QR code encoding
-- `build/` — Version string (currently "0.20.1"), date/time injected at build
+- `build/` — Version string (currently "0.20.2"), date/time injected at build
 - `web-content/` — Static assets under `public/`, SPA build output under `admin/spa/`
 
 ### Route Groups (`web/app.go`)

--- a/docker/card/admin-ui/src/components/two-factor-card.tsx
+++ b/docker/card/admin-ui/src/components/two-factor-card.tsx
@@ -134,7 +134,14 @@ export function TwoFactorCard() {
                   inputMode="numeric"
                   value={code}
                   onChange={(e) => setCode(e.target.value.trim())}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && code.length > 0 && !enable.isPending) {
+                      e.preventDefault();
+                      enable.mutate();
+                    }
+                  }}
                   placeholder="123456"
+                  autoFocus
                 />
               </div>
             </div>

--- a/docker/card/build/build.go
+++ b/docker/card/build/build.go
@@ -1,5 +1,5 @@
 package build
 
-var Version string = "0.20.1"
+var Version string = "0.20.2"
 var Date string
 var Time string

--- a/docker/card/web/totp.go
+++ b/docker/card/web/totp.go
@@ -8,11 +8,15 @@ import (
 )
 
 // newTotpKey generates a fresh TOTP secret for the admin. accountName is the
-// label shown in the authenticator app (we pass host_domain). Returns the
-// base32 secret and the otpauth:// provisioning URI.
+// label shown in the authenticator app (we pass host_domain). The issuer is
+// "Boltcard Hub" (one token) to avoid wrong-logo brand matching in Authy.
+// Returns the base32 secret and the otpauth:// provisioning URI.
 func newTotpKey(accountName string) (secret string, url string, err error) {
 	key, err := totp.Generate(totp.GenerateOpts{
-		Issuer:      "Bolt Card Hub",
+		// "Boltcard" as a single token (not "Bolt Card") so authenticator apps
+		// that pick a logo by matching the issuer (e.g. Authy) don't false-match
+		// the unrelated "Bolt" brand and suggest the wrong logo.
+		Issuer:      "Boltcard Hub",
 		AccountName: accountName,
 	})
 	if err != nil {

--- a/docker/card/web/totp_test.go
+++ b/docker/card/web/totp_test.go
@@ -19,6 +19,11 @@ func TestNewTotpKey_ProducesValidatableSecret(t *testing.T) {
 	if !strings.HasPrefix(url, "otpauth://totp/") {
 		t.Fatalf("expected otpauth URI, got %q", url)
 	}
+	// Issuer must be the single-token "Boltcard" so Authy doesn't match the
+	// unrelated "Bolt" brand and suggest the wrong logo.
+	if !strings.Contains(url, "Boltcard") {
+		t.Fatalf("expected 'Boltcard' issuer in URI, got %q", url)
+	}
 
 	code, err := totp.GenerateCode(secret, time.Now())
 	if err != nil {


### PR DESCRIPTION
## Summary
Two small admin 2FA **enrollment** improvements (Settings → Two-Factor Authentication):

1. **Submit confirm code on Enter** — the 6-digit code field triggers **Confirm** on Enter (same guard as the button: non-empty, not already verifying) and autofocuses when the enrollment dialog opens.
2. **Avoid the wrong Authy logo** — the otpauth issuer changes from `Bolt Card Hub` to **`Boltcard Hub`**. Authy picks a logo by matching the issuer against its own brand database and was false-matching the unrelated **Bolt** brand. A single "Boltcard" token makes it fall back to a neutral icon. (The otpauth standard has no logo field and Authy ignores any embedded `image=`, so the issuer string is the only available lever — effect on Authy can't be verified from CI.)

No API/backend behavior changes beyond the issuer string. Existing enrollments are unaffected (issuer is embedded per-enrollment at setup time).

Version bump 0.20.1 → 0.20.2 (PATCH per SemVer).

## Test Plan
- [x] `go test -race ./...` and `npm run build` pass; `totp_test.go` asserts the `Boltcard` issuer.
- [ ] Settings → Enable 2FA → type code → press Enter → enrollment confirms.
- [ ] Empty field + Enter does nothing; Enter while "Verifying..." doesn't double-submit.
- [ ] Scan the new QR in Authy → no longer shows the wrong (Bolt) logo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)