### PR TITLE
Show per-commit version marker in About > Recent Commits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Entry point: `main.go` → opens SQLite DB → runs CLI or starts HTTP server on
 - `phoenix/` — HTTP client for Phoenix Server API (invoices, payments, balance, channels). Uses basic auth from phoenix config (password cached at startup with `sync.Once`)
 - `crypto/` — AES-CMAC authentication and AES decryption for Bolt Card NFC protocol
 - `util/` — Error handling helpers (`CheckAndLog`), random hex generation, QR code encoding
-- `build/` — Version string (currently "0.20.2"), date/time injected at build
+- `build/` — Version string (currently "0.21.0"), date/time injected at build
 - `web-content/` — Static assets under `public/`, SPA build output under `admin/spa/`
 
 ### Route Groups (`web/app.go`)

--- a/docker/card/admin-ui/src/pages/about.tsx
+++ b/docker/card/admin-ui/src/pages/about.tsx
@@ -38,6 +38,7 @@ interface Commit {
   sha: string;
   message: string;
   date: string;
+  version: string;
 }
 
 interface CommitsData {
@@ -226,7 +227,7 @@ export function AboutPage() {
                 </h3>
                 <ul className="space-y-1">
                   {commits.map((c) => (
-                    <li key={c.sha}>
+                    <li key={c.sha} className="flex items-baseline gap-2">
                       <a
                         href={`https://github.com/boltcard/hub/commit/${c.sha}`}
                         target="_blank"
@@ -235,6 +236,11 @@ export function AboutPage() {
                       >
                         {c.message}
                       </a>
+                      {c.version && (
+                        <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                          v{c.version}
+                        </span>
+                      )}
                     </li>
                   ))}
                 </ul>

--- a/docker/card/build/build.go
+++ b/docker/card/build/build.go
@@ -1,5 +1,5 @@
 package build
 
-var Version string = "0.20.2"
+var Version string = "0.21.0"
 var Date string
 var Time string

--- a/docker/card/web/admin_api_about.go
+++ b/docker/card/web/admin_api_about.go
@@ -2,12 +2,14 @@ package web
 
 import (
 	"card/build"
+	"encoding/base64"
 	"encoding/json"
 	"html"
 	"io"
 	"net/http"
 	"regexp"
 	"strings"
+	"sync"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -79,6 +81,7 @@ func (app *App) adminApiCommits(w http.ResponseWriter, r *http.Request) {
 		Sha     string `json:"sha"`
 		Message string `json:"message"`
 		Date    string `json:"date"`
+		Version string `json:"version"`
 	}
 
 	var commits []commit
@@ -123,11 +126,91 @@ func (app *App) adminApiCommits(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Annotate each commit with the app version recorded in build/build.go at
+	// that commit. The commits-list API doesn't return file contents, so this
+	// needs one extra fetch per commit; results are cached by SHA (immutable)
+	// and fetched concurrently so a cold load doesn't serialise 10 round-trips.
+	var wg sync.WaitGroup
+	for i := range commits {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			commits[i].Version = fetchCommitVersion(client, commits[i].Sha)
+		}(i)
+	}
+	wg.Wait()
+
 	if commits == nil {
 		commits = []commit{}
 	}
 
 	writeJSON(w, map[string]interface{}{"commits": commits})
+}
+
+var buildVersionRegex = regexp.MustCompile(`Version string = "([^"]+)"`)
+
+// parseVersionFromBuildGo extracts the version string from build/build.go
+// source, returning "" if no version declaration is found.
+func parseVersionFromBuildGo(content string) string {
+	m := buildVersionRegex.FindStringSubmatch(content)
+	if len(m) == 2 {
+		return m[1]
+	}
+	return ""
+}
+
+var (
+	commitVersionMu    sync.Mutex
+	commitVersionCache = map[string]string{}
+)
+
+// fetchCommitVersion returns the app version recorded in build/build.go at the
+// given commit SHA, fetching it from the GitHub contents API. Results are
+// memoised per SHA — a commit's tree is immutable, so the cache never goes
+// stale. Returns "" on any error (rate limit, missing file in old commits).
+func fetchCommitVersion(client *http.Client, sha string) string {
+	if sha == "" {
+		return ""
+	}
+
+	commitVersionMu.Lock()
+	if v, ok := commitVersionCache[sha]; ok {
+		commitVersionMu.Unlock()
+		return v
+	}
+	commitVersionMu.Unlock()
+
+	url := "https://api.github.com/repos/boltcard/hub/contents/docker/card/build/build.go?ref=" + sha
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+
+	version := ""
+	if resp.StatusCode == 200 {
+		var payload struct {
+			Content  string `json:"content"`
+			Encoding string `json:"encoding"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err == nil && payload.Encoding == "base64" {
+			// GitHub wraps base64 content at 60 chars with newlines.
+			decoded, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(payload.Content, "\n", ""))
+			if err == nil {
+				version = parseVersionFromBuildGo(string(decoded))
+			}
+		}
+	}
+
+	commitVersionMu.Lock()
+	commitVersionCache[sha] = version
+	commitVersionMu.Unlock()
+	return version
 }
 
 var ansiColorMap = map[string]string{

--- a/docker/card/web/admin_api_about_test.go
+++ b/docker/card/web/admin_api_about_test.go
@@ -1,0 +1,40 @@
+package web
+
+import "testing"
+
+func TestParseVersionFromBuildGo(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "current format",
+			content: "package build\n\nvar Version string = \"0.20.1\"\nvar Date string\nvar Time string\n",
+			want:    "0.20.1",
+		},
+		{
+			name:    "older multi-digit version",
+			content: "var Version string = \"0.2.10\"\n",
+			want:    "0.2.10",
+		},
+		{
+			name:    "no version line",
+			content: "package build\n\nvar Date string\n",
+			want:    "",
+		},
+		{
+			name:    "empty content",
+			content: "",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseVersionFromBuildGo(tt.content); got != tt.want {
+				t.Errorf("parseVersionFromBuildGo() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Each commit in the About page's **Recent Commits** list now shows the app version (`vX.Y.Z`) recorded in `build/build.go` at that commit, rendered as a muted monospace tag at the end of the row. Because the version is bumped per PR, the marker visibly changes down the list:

```
Bump version to 0.20.0 and document admin 2FA            v0.20.0
Surface error when a submitted 2FA code is rejected…     v0.19.9
```

## How

The GitHub commits-list API doesn't return file contents, so `adminApiCommits` fetches `build/build.go` at each commit SHA via the contents API and parses the `Version` constant:

- **Cached by SHA** — a commit's tree is immutable, so the cache never goes stale and repeat About loads cost no extra GitHub calls.
- **Concurrent fetches** — a cold load doesn't serialise the per-commit round-trips.
- **Graceful degradation** — any fetch error (rate limit, missing file in pre-`build.go` history) yields an empty marker, which the frontend simply omits.

## Changes

- `web/admin_api_about.go` — per-commit version fetch + SHA cache + parser
- `web/admin_api_about_test.go` — new test for the pure version parser (TDD)
- `admin-ui/src/pages/about.tsx` — `version` field + render tag per row
- `build/build.go` + `CLAUDE.md` — version bump `0.20.2 → 0.21.0` (new feature, MINOR)

## Verification

- `go vet ./...` — clean
- `go test -race -count=1 ./web/ ./crypto/ ./db/` — all `ok`
- `npm run build` (admin-ui) — built, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)