### PR TITLE
2FA: close recovery-codes modal on Enter (0.22.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Entry point: `main.go` → opens SQLite DB → runs CLI or starts HTTP server on
 - `phoenix/` — HTTP client for Phoenix Server API (invoices, payments, balance, channels). Uses basic auth from phoenix config (password cached at startup with `sync.Once`)
 - `crypto/` — AES-CMAC authentication and AES decryption for Bolt Card NFC protocol
 - `util/` — Error handling helpers (`CheckAndLog`), random hex generation, QR code encoding
-- `build/` — Version string (currently "0.22.0"), date/time injected at build
+- `build/` — Version string (currently "0.22.1"), date/time injected at build
 - `web-content/` — Static assets under `public/`, SPA build output under `admin/spa/`
 
 ### Route Groups (`web/app.go`)

--- a/docker/card/admin-ui/src/components/two-factor-card.tsx
+++ b/docker/card/admin-ui/src/components/two-factor-card.tsx
@@ -171,7 +171,14 @@ export function TwoFactorCard() {
 
       {/* Recovery codes shown once */}
       <Dialog open={!!recoveryCodes} onOpenChange={(o) => !o && setRecoveryCodes(null)}>
-        <DialogContent>
+        <DialogContent
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              setRecoveryCodes(null);
+            }
+          }}
+        >
           <DialogHeader>
             <DialogTitle>Save your recovery codes</DialogTitle>
           </DialogHeader>

--- a/docker/card/build/build.go
+++ b/docker/card/build/build.go
@@ -1,5 +1,5 @@
 package build
 
-var Version string = "0.22.0"
+var Version string = "0.22.1"
 var Date string
 var Time string


### PR DESCRIPTION
## Summary
- Pressing **Enter** on the 2FA recovery-codes modal now activates the **Done** button (closes the dialog), matching the behaviour of the enrollment ("2FA check") modal where Enter submits the code.
- Implemented via an `onKeyDown` handler on the recovery-codes `DialogContent`: Enter calls `preventDefault()` (which also suppresses the default Enter-activation of whichever button is focused, e.g. Copy) and clears the codes state to close. Mirrors the enrollment modal's existing pattern.

## Why
The recovery-codes dialog had no keyboard shortcut for its primary action; users had to click Done. This makes the keyboard UX consistent with the other 2FA modal.

## Version
Bump `0.22.0` → `0.22.1` (PATCH — frontend-only UX tweak).

## Testing
- `npm run build` in `docker/card/admin-ui/` passes (frontend-only change; no FE test runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)