### PR TITLE
CI: cut `go test -race` time by lowering bcrypt cost in tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Entry point: `main.go` → opens SQLite DB → runs CLI or starts HTTP server on
 - `phoenix/` — HTTP client for Phoenix Server API (invoices, payments, balance, channels). Uses basic auth from phoenix config (password cached at startup with `sync.Once`)
 - `crypto/` — AES-CMAC authentication and AES decryption for Bolt Card NFC protocol
 - `util/` — Error handling helpers (`CheckAndLog`), random hex generation, QR code encoding
-- `build/` — Version string (currently "0.22.2"), date/time injected at build
+- `build/` — Version string (currently "0.22.3"), date/time injected at build
 - `web-content/` — Static assets under `public/`, SPA build output under `admin/spa/`
 
 ### Route Groups (`web/app.go`)

--- a/docker/card/build/build.go
+++ b/docker/card/build/build.go
@@ -1,5 +1,5 @@
 package build
 
-var Version string = "0.22.2"
+var Version string = "0.22.3"
 var Date string
 var Time string

--- a/docker/card/web/main_test.go
+++ b/docker/card/web/main_test.go
@@ -1,0 +1,19 @@
+package web
+
+import (
+	"os"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// TestMain lowers the bcrypt work factor for the whole web test package.
+// Production keeps bcrypt.DefaultCost (see HashPassword in util.go); the
+// admin-login and 2FA recovery-code tests hash dozens of values per run, and
+// at DefaultCost that hashing — amplified by the race detector — dominated
+// CI's `go test -race` step (~3 min). MinCost keeps the hashing path fully
+// exercised while making it roughly 64x cheaper.
+func TestMain(m *testing.M) {
+	bcryptCost = bcrypt.MinCost
+	os.Exit(m.Run())
+}

--- a/docker/card/web/util.go
+++ b/docker/card/web/util.go
@@ -25,8 +25,14 @@ func GetPwHash(db_conn *sql.DB, passwordStr string) (passwordHashStr string) {
 	return passwordHashStr
 }
 
+// bcryptCost is the work factor used for all password/recovery-code hashing.
+// Production keeps bcrypt.DefaultCost; the test suite lowers it (see TestMain
+// in main_test.go) because the admin-login and 2FA tests hash dozens of values
+// and at DefaultCost that alone dominated CI's `go test -race` step.
+var bcryptCost = bcrypt.DefaultCost
+
 func HashPassword(passwordStr string) (string, error) {
-	hash, err := bcrypt.GenerateFromPassword([]byte(passwordStr), bcrypt.DefaultCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(passwordStr), bcryptCost)
 	return string(hash), err
 }
 


### PR DESCRIPTION
## Problem

`CI / build (push)` runs ~3 min and is the gate before `docker-card`, so it paces the whole pipeline. Per-step timings from recent `main` runs show the **Test step is ~90% of the job**:

| Step | #43 merge | #42 merge |
|------|----------|----------|
| setup-go / vet / build | 10s | 12s |
| **Test (`go test -race`)** | **2m55s** | **3m17s** |
| govulncheck | 4s | 3s |

Within the suite, the `web` package is ~95% of test time, and its slowest tests are all **bcrypt-bound**: every `setupAdminSession` hashes a password, and the 2FA tests hash **10 recovery codes each** at `bcrypt.DefaultCost` (~80ms/hash), amplified ~2× by the race detector.

## Fix

All hashing routes through one function, so a single knob covers it:

- `web/util.go` — `HashPassword` now reads a package var `bcryptCost`. **Production is unchanged** (defaults to `bcrypt.DefaultCost`).
- `web/main_test.go` — new `TestMain` sets `bcryptCost = bcrypt.MinCost` for the web test package only (~64× fewer rounds). `CompareHashAndPassword` reads the cost from the hash, so login/recovery verification gets cheaper too and the hashing path stays fully exercised.

## Measured (1-core box; CI has 4 cores, ratios hold)

| | Before | After |
|---|---|---|
| `web` pkg, `-race` | 3m51s | **26s** |
| `web` pkg CPU (user) | 3m17s | 10.6s |
| full `./...` `-race` | — | **34s, all green** |

CI's ~3-min Test step should drop to well under a minute (race-compile of changed packages becomes the floor).

Version bumped `0.22.2 → 0.22.3` (PATCH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)